### PR TITLE
Idea: Throw error when Provider not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.1
+
+- `Provider.of<T>` now crashes with a `ProviderNotFoundException` when no `Provider<T>` are found in the ancestors of the context used.
+
 # 1.6.0
 
 - new: `ChangeNotifierProvider`, similar to scoped_model that exposes `ChangeNotifer` subclass and rebuilds dependents only when `notifyListeners` is called.

--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -1,10 +1,10 @@
 library provider;
 
 export 'src/consumer.dart';
-
 export 'src/provider.dart'
     show
         Provider,
+        ProviderNotFoundError,
         StatefulProvider,
         HookProvider,
         StreamProvider,

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -60,10 +60,7 @@ class Provider<T> extends InheritedWidget implements ProviderBase {
             as Provider<T>;
 
     if (provider == null) {
-      throw ProviderNotFoundError(
-        T.toString(),
-        context.widget.runtimeType.toString(),
-      );
+      throw ProviderNotFoundError(T, context.widget.runtimeType);
     }
 
     return provider.value;
@@ -598,10 +595,10 @@ class ValueListenableProvider<T> extends HookProvider<T> {
 /// Widget tree.
 class ProviderNotFoundError extends Error {
   /// The type of the value being retrieved
-  final String valueType;
+  final Type valueType;
 
   /// The type of the Widget requesting the value
-  final String widgetType;
+  final Type widgetType;
 
   /// Create a ProviderNotFound error with the type represented as a String.
   ProviderNotFoundError(
@@ -625,17 +622,6 @@ To fix, please:
 
 If none of these solutions work, please file a bug at:
 https://github.com/rrousselGit/provider/issues
-      ''';
+''';
   }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ProviderNotFoundError &&
-          runtimeType == other.runtimeType &&
-          valueType == other.valueType &&
-          widgetType == other.widgetType;
-
-  @override
-  int get hashCode => valueType.hashCode ^ widgetType.hashCode;
 }

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -58,7 +58,12 @@ class Provider<T> extends InheritedWidget implements ProviderBase {
         ? context.inheritFromWidgetOfExactType(type) as Provider<T>
         : context.ancestorInheritedElementForWidgetOfExactType(type)?.widget
             as Provider<T>;
-    return provider?.value;
+
+    if (provider == null) {
+      throw ProviderNotFoundError();
+    }
+
+    return provider.value;
   }
 
   @override
@@ -584,4 +589,25 @@ class ValueListenableProvider<T> extends HookProvider<T> {
   ///
   /// It is fine to change the instance of [valueListenable].
   final ValueListenable<T> valueListenable;
+}
+
+/// The error that will be thrown if the Provider cannot be found in the
+/// Widget tree.
+class ProviderNotFoundError extends Error {
+  @override
+  String toString() {
+    return '''Error: Could not find the correct Provider.
+    
+To fix, please:
+          
+  * Provide types to Provider<MyClass>
+  * Provide types to Consumer<MyClass> 
+  * Provide types to Provider.of<MyClass>() 
+  * Always use package imports. Ex: `import 'package:my_app/my_code.dart';
+  * Ensure the correct `context` is being used.
+  
+If none of these solutions work, please file a bug at:
+https://github.com/rrousselGit/provider/issues
+      ''';
+  }
 }

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -597,26 +597,29 @@ class ValueListenableProvider<T> extends HookProvider<T> {
 /// The error that will be thrown if the Provider cannot be found in the
 /// Widget tree.
 class ProviderNotFoundError extends Error {
-  final String _type;
-  final String _currentWidget;
+  /// The type of the value being retrieved
+  final String valueType;
+
+  /// The type of the Widget requesting the value
+  final String widgetType;
 
   /// Create a ProviderNotFound error with the type represented as a String.
   ProviderNotFoundError(
-    this._type,
-    this._currentWidget,
+    this.valueType,
+    this.widgetType,
   );
 
   @override
   String toString() {
     return '''
-Error: Could not find the correct Provider<$_type> above this $_currentWidget Widget 
+Error: Could not find the correct Provider<$valueType> above this $widgetType Widget 
 
 To fix, please:
 
-  * Ensure the Provider<$_type> is an ancestor to this $_currentWidget Widget 
-  * Provide types to Provider<$_type>
-  * Provide types to Consumer<$_type>
-  * Provide types to Provider.of<$_type>()
+  * Ensure the Provider<$valueType> is an ancestor to this $widgetType Widget 
+  * Provide types to Provider<$valueType>
+  * Provide types to Consumer<$valueType>
+  * Provide types to Provider.of<$valueType>()
   * Always use package imports. Ex: `import 'package:my_app/my_code.dart';
   * Ensure the correct `context` is being used.
 
@@ -624,4 +627,15 @@ If none of these solutions work, please file a bug at:
 https://github.com/rrousselGit/provider/issues
       ''';
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ProviderNotFoundError &&
+          runtimeType == other.runtimeType &&
+          valueType == other.valueType &&
+          widgetType == other.widgetType;
+
+  @override
+  int get hashCode => valueType.hashCode ^ widgetType.hashCode;
 }

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -60,7 +60,10 @@ class Provider<T> extends InheritedWidget implements ProviderBase {
             as Provider<T>;
 
     if (provider == null) {
-      throw ProviderNotFoundError();
+      throw ProviderNotFoundError(
+        T.toString(),
+        context.widget.runtimeType.toString(),
+      );
     }
 
     return provider.value;
@@ -594,18 +597,29 @@ class ValueListenableProvider<T> extends HookProvider<T> {
 /// The error that will be thrown if the Provider cannot be found in the
 /// Widget tree.
 class ProviderNotFoundError extends Error {
+  final String _type;
+  final String _currentWidget;
+
+  /// Create a ProviderNotFound error with the type represented as a String.
+  ProviderNotFoundError(
+    this._type,
+    this._currentWidget,
+  );
+
   @override
   String toString() {
-    return '''Error: Could not find the correct Provider.
-    
+    return '''
+Error: Could not find the correct Provider<$_type> above this $_currentWidget Widget 
+
 To fix, please:
-          
-  * Provide types to Provider<MyClass>
-  * Provide types to Consumer<MyClass> 
-  * Provide types to Provider.of<MyClass>() 
+
+  * Ensure the Provider<$_type> is an ancestor to this $_currentWidget Widget 
+  * Provide types to Provider<$_type>
+  * Provide types to Consumer<$_type>
+  * Provide types to Provider.of<$_type>()
   * Always use package imports. Ex: `import 'package:my_app/my_code.dart';
   * Ensure the correct `context` is being used.
-  
+
 If none of these solutions work, please file a bug at:
 https://github.com/rrousselGit/provider/issues
       ''';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: provider
 description: An helper to easily exposes a value using InheritedWidget without having to write one.
-version: 1.6.0
+version: 1.6.1
 homepage: https://github.com/rrousselGit/provider
 author: Remi Rousselet <darky12s@gmail.com>
 

--- a/test/multi_provider_test.dart
+++ b/test/multi_provider_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' hide TypeMatcher;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
@@ -45,7 +45,6 @@ void main() {
       final p1 = Provider(key: k1, value: 42);
       final p2 = Provider(key: k2, value: 'foo');
       final p3 = Provider(key: k3, value: 44.0);
-      final throwsNotFound = throwsA(isInstanceOf<ProviderNotFoundError>());
 
       final keyChild = GlobalKey();
       await tester.pumpWidget(MultiProvider(
@@ -57,13 +56,22 @@ void main() {
 
       // p1 cannot access to /p2/p3
       expect(Provider.of<int>(k1.currentContext), 42);
-      expect(() => Provider.of<String>(k1.currentContext), throwsNotFound);
-      expect(() => Provider.of<double>(k1.currentContext), throwsNotFound);
+      expect(
+        () => Provider.of<String>(k1.currentContext),
+        throwsA(ProviderNotFoundError('String', 'Provider<int>')),
+      );
+      expect(
+        () => Provider.of<double>(k1.currentContext),
+        throwsA(ProviderNotFoundError('double', 'Provider<int>')),
+      );
 
       // p2 can access only p1
       expect(Provider.of<int>(k2.currentContext), 42);
       expect(Provider.of<String>(k2.currentContext), 'foo');
-      expect(() => Provider.of<double>(k2.currentContext), throwsNotFound);
+      expect(
+        () => Provider.of<double>(k2.currentContext),
+        throwsA(ProviderNotFoundError('double', 'Provider<String>')),
+      );
 
       // p3 can access both p1 and p2
       expect(Provider.of<int>(k3.currentContext), 42);

--- a/test/multi_provider_test.dart
+++ b/test/multi_provider_test.dart
@@ -37,16 +37,7 @@ void main() {
       expect(find.text('Foo'), findsOneWidget);
     });
 
-    testWidgets('MultiProvider with empty providers returns child',
-        (tester) async {
-      await tester.pumpWidget(const MultiProvider(
-        providers: [],
-        child: Text('Foo', textDirection: TextDirection.ltr),
-      ));
-
-      expect(find.text('Foo'), findsOneWidget);
-    });
-    testWidgets('MultiProvider with empty providers returns child',
+    testWidgets('MultiProvider children can only access parent providers',
         (tester) async {
       final k1 = GlobalKey();
       final k2 = GlobalKey();
@@ -54,6 +45,7 @@ void main() {
       final p1 = Provider(key: k1, value: 42);
       final p2 = Provider(key: k2, value: 'foo');
       final p3 = Provider(key: k3, value: 44.0);
+      final throwsNotFound = throwsA(isInstanceOf<ProviderNotFoundError>());
 
       final keyChild = GlobalKey();
       await tester.pumpWidget(MultiProvider(
@@ -65,13 +57,13 @@ void main() {
 
       // p1 cannot access to /p2/p3
       expect(Provider.of<int>(k1.currentContext), 42);
-      expect(Provider.of<String>(k1.currentContext), isNull);
-      expect(Provider.of<double>(k1.currentContext), isNull);
+      expect(() => Provider.of<String>(k1.currentContext), throwsNotFound);
+      expect(() => Provider.of<double>(k1.currentContext), throwsNotFound);
 
       // p2 can access only p1
       expect(Provider.of<int>(k2.currentContext), 42);
       expect(Provider.of<String>(k2.currentContext), 'foo');
-      expect(Provider.of<double>(k2.currentContext), isNull);
+      expect(() => Provider.of<double>(k2.currentContext), throwsNotFound);
 
       // p3 can access both p1 and p2
       expect(Provider.of<int>(k3.currentContext), 42);

--- a/test/multi_provider_test.dart
+++ b/test/multi_provider_test.dart
@@ -1,6 +1,15 @@
 import 'package:flutter/widgets.dart' hide TypeMatcher;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:matcher/matcher.dart';
 import 'package:provider/provider.dart';
+
+Type _typeOf<T>() => T;
+
+Matcher throwsProviderNotFound({Type widgetType, Type valueType}) {
+  return throwsA(const TypeMatcher<ProviderNotFoundError>()
+      .having((err) => err.valueType, 'valueType', valueType)
+      .having((err) => err.widgetType, 'widgetType', widgetType));
+}
 
 void main() {
   group('MultiProvider', () {
@@ -58,11 +67,13 @@ void main() {
       expect(Provider.of<int>(k1.currentContext), 42);
       expect(
         () => Provider.of<String>(k1.currentContext),
-        throwsA(ProviderNotFoundError('String', 'Provider<int>')),
+        throwsProviderNotFound(
+            valueType: String, widgetType: _typeOf<Provider<int>>()),
       );
       expect(
         () => Provider.of<double>(k1.currentContext),
-        throwsA(ProviderNotFoundError('double', 'Provider<int>')),
+        throwsProviderNotFound(
+            valueType: double, widgetType: _typeOf<Provider<int>>()),
       );
 
       // p2 can access only p1
@@ -70,7 +81,8 @@ void main() {
       expect(Provider.of<String>(k2.currentContext), 'foo');
       expect(
         () => Provider.of<double>(k2.currentContext),
-        throwsA(ProviderNotFoundError('double', 'Provider<String>')),
+        throwsProviderNotFound(
+            valueType: double, widgetType: _typeOf<Provider<String>>()),
       );
 
       // p3 can access both p1 and p2

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' hide TypeMatcher;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/src/provider.dart';
@@ -110,11 +110,12 @@ void main() {
     });
 
     testWidgets('throws an error if no provider found', (tester) async {
-      await tester.pumpWidget(
-        const Builder(builder: Provider.of),
-      );
+      await tester.pumpWidget(const Builder(builder: Provider.of));
 
-      expect(tester.takeException(), isInstanceOf<ProviderNotFoundError>());
+      expect(
+        tester.takeException(),
+        ProviderNotFoundError('Widget', 'Builder'),
+      );
     });
 
     testWidgets('update should notify', (tester) async {

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart' hide TypeMatcher;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/src/provider.dart';
+import 'package:test_api/test_api.dart' show TypeMatcher;
 
 void main() {
   group('Provider', () {
@@ -110,11 +111,31 @@ void main() {
     });
 
     testWidgets('throws an error if no provider found', (tester) async {
-      await tester.pumpWidget(const Builder(builder: Provider.of));
+      await tester.pumpWidget(Builder(builder: (context) {
+        Provider.of<String>(context);
+        return Container();
+      }));
 
       expect(
         tester.takeException(),
-        ProviderNotFoundError('Widget', 'Builder'),
+        const TypeMatcher<ProviderNotFoundError>()
+            .having((err) => err.valueType, 'valueType', String)
+            .having((err) => err.widgetType, 'widgetType', Builder)
+            .having((err) => err.toString(), 'toString()', '''
+Error: Could not find the correct Provider<String> above this Builder Widget 
+
+To fix, please:
+
+  * Ensure the Provider<String> is an ancestor to this Builder Widget 
+  * Provide types to Provider<String>
+  * Provide types to Consumer<String>
+  * Provide types to Provider.of<String>()
+  * Always use package imports. Ex: `import 'package:my_app/my_code.dart';
+  * Ensure the correct `context` is being used.
+
+If none of these solutions work, please file a bug at:
+https://github.com/rrousselGit/provider/issues
+'''),
       );
     });
 

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -41,7 +41,6 @@ void main() {
       var buildCount = 0;
       int value;
       double second;
-      String missing;
 
       // We voluntarily reuse the builder instance so that later call to pumpWidget
       // don't call builder again unless subscribed to an inheritedWidget
@@ -49,7 +48,6 @@ void main() {
         builder: (context) {
           buildCount++;
           value = Provider.of(context);
-          missing = Provider.of(context);
           second = Provider.of(context, listen: false);
           return Container();
         },
@@ -67,7 +65,6 @@ void main() {
 
       expect(value, equals(42));
       expect(second, equals(24.0));
-      expect(missing, isNull);
       expect(buildCount, equals(1));
 
       // nothing changed
@@ -95,7 +92,6 @@ void main() {
       );
       expect(value, equals(43));
       expect(second, equals(24.0));
-      expect(missing, isNull);
       // got rebuilt
       expect(buildCount, equals(2));
 
@@ -111,6 +107,14 @@ void main() {
       );
       // didn't get rebuilt
       expect(buildCount, equals(2));
+    });
+
+    testWidgets('throws an error if no provider found', (tester) async {
+      await tester.pumpWidget(
+        const Builder(builder: Provider.of),
+      );
+
+      expect(tester.takeException(), isInstanceOf<ProviderNotFoundError>());
     });
 
     testWidgets('update should notify', (tester) async {


### PR DESCRIPTION
Right now, the Provider.of method returns `null` if a provider isn't found. 

My guess: This leads to subtle runtime errors, and might leave users wondering what went wrong! This PR changes the `of` method. Now, if no provider is found, an error is immediately thrown (Fail Fast) and gives advice to the developer as to why the provider might not be returning a value.

This same type of code was added to ScopedModel after receiving several error reports when users ran into this exact problem. This error messaging has dramatically cut down on the number of open issues, so I think it's working well!

