### PR TITLE
remove updateShouldNotify parameter from Provider.

### DIFF
--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -190,10 +190,10 @@ class Provider<T> extends AdaptiveBuilderWidget<T, T>
   const Provider({
     Key key,
     @required ValueBuilder<T> builder,
-    this.updateShouldNotify,
     this.dispose,
     this.child,
   })  : assert(builder != null),
+        updateShouldNotify = null,
         super(key: key, builder: builder);
 
   /// Allows to specify parameters to [Provider]
@@ -232,7 +232,6 @@ class Provider<T> extends AdaptiveBuilderWidget<T, T>
             builder: builder,
             key: key,
             dispose: dispose,
-            updateShouldNotify: updateShouldNotify,
           )
         : Provider<T>.value(
             key: key,

--- a/test/stateful_provider_test.dart
+++ b/test/stateful_provider_test.dart
@@ -18,7 +18,6 @@ void main() {
       builder: (_) => 42,
       child: Container(),
       key: const ValueKey(42),
-      updateShouldNotify: (int _, int __) => true,
     );
 
     final newChild = Container();
@@ -70,23 +69,5 @@ void main() {
     verifyZeroInteractions(dispose);
     await tester.pumpWidget(Container());
     verify(dispose(context, 42)).called(1);
-  });
-
-  testWidgets('update should notify', (tester) async {
-    final updateShouldNotify = (int a, int b) => true;
-
-    await tester.pumpWidget(
-      Provider<int>(
-        builder: (_) => 42,
-        updateShouldNotify: updateShouldNotify,
-        child: Container(),
-      ),
-    );
-
-    final provider =
-        tester.widget(find.byWidgetPredicate((w) => w is Provider<int>))
-            as Provider<int>;
-
-    expect(provider.updateShouldNotify, updateShouldNotify);
   });
 }


### PR DESCRIPTION
This removed the parameter `updateShouldNotify` from `Provider` constructor (it is still available using `Provider.value`).

It made no sense to be able to pass an `updateShouldNotify` since, by principle, the builder constructor of `Provider` will always provide the same value.