### PR TITLE
Fix broken doc formatting

### DIFF
--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -148,7 +148,8 @@ class MultiProvider extends StatelessWidget
 /// [updateShouldNotify] can optionally be passed to avoid unnecessaryly rebuilding dependants when nothing changed.
 /// Defaults to `(previous, next) => previous != next`. See [InheritedWidget.updateShouldNotify] for more informations.
 /// {@endtemplate}
-/// ```
+///
+/// ```dart
 /// class Model {
 ///   void dispose() {}
 /// }


### PR DESCRIPTION
The code sample here isn't being formatted correctly (see https://pub.dev/documentation/provider/latest/provider/Provider-class.html). I think this change should fix it.