### PR TITLE
Prevent Provider from using Listenable/Stream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## breaking (see the readme for migration steps):
 
+- `Provider` now throws if used with a `Listenable`/`Stream`. This can be disabled by setting
+  `Provider.debugCheckInvalidValueType` to `null`.
 - The default constructor of `StreamProvider` has now builds a `Stream`
   instead of `StreamController`. The previous behavior has been moved to `StreamProvider.controller`.
 - All `XXProvider.value` constructors now use `value` as parameter name.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,26 @@ to make common use-cases straightforward.
 ## Migration from v2.0.0 to v3.0.0
 
 - Providers can no longer be instantiated with `const`.
+- `Provider` now throws if used with a `Listenable`/`Stream`.
+  Consider using `ListenableProvider`/`StreamProvider` instead. Alternatively,
+  this exception can be disabled by setting `Provider.debugCheckInvalidValueType`
+  to `null` like so:
+
+```dart
+void main() {
+  Provider.debugCheckInvalidValueType = null;
+
+  runApp(MyApp());
+}
+```
+
+
 - All `XXProvider.value` constructors now use `value` as parameter name.
 
 Before:
 
 ```dart
 ChangeNotifierProvider.value(notifier: myNotifier),
-),
 ```
 
 After:
@@ -28,7 +41,6 @@ Before:
 
 ```dart
 StreamProvider(builder: (_) => StreamController<int>()),
-),
 ```
 
 After:

--- a/lib/src/proxy_provider.dart
+++ b/lib/src/proxy_provider.dart
@@ -175,6 +175,10 @@ class NumericProxyProvider<F extends Function, T, T2, T3, T4, T5, T6, R>
 
   @override
   Widget build(BuildContext context, R value) {
+    assert(() {
+      Provider.debugCheckInvalidValueType?.call(value);
+      return true;
+    }());
     return InheritedProvider<R>(
       value: value,
       updateShouldNotify: updateShouldNotify,

--- a/test/common.dart
+++ b/test/common.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -90,5 +92,15 @@ class Combined extends DiagnosticableTree {
       DiagnosticsProperty('previous', previous, defaultValue: null),
       DiagnosticsProperty('context', context, defaultValue: null),
     ]);
+  }
+}
+
+class MyListenable extends ChangeNotifier {}
+
+class MyStream extends Stream<void> {
+  @override
+  StreamSubscription<void> listen(void Function(void event) onData,
+      {Function onError, void Function() onDone, bool cancelOnError}) {
+    return null;
   }
 }

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -4,8 +4,49 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:test_api/test_api.dart' show TypeMatcher;
 
+import 'common.dart';
+
 void main() {
   group('Provider', () {
+    testWidgets('throws if the provided value is a Listenable/Stream',
+        (tester) async {
+      await tester.pumpWidget(
+        Provider.value(
+          value: MyListenable(),
+          child: Container(),
+        ),
+      );
+
+      expect(tester.takeException(), isFlutterError);
+
+      await tester.pumpWidget(
+        Provider.value(
+          value: MyStream(),
+          child: Container(),
+        ),
+      );
+
+      expect(tester.takeException(), isFlutterError);
+    });
+    testWidgets('debugCheckInvalidValueType can be disabled', (tester) async {
+      final previous = Provider.debugCheckInvalidValueType;
+      Provider.debugCheckInvalidValueType = null;
+      addTearDown(() => Provider.debugCheckInvalidValueType = previous);
+
+      await tester.pumpWidget(
+        Provider.value(
+          value: MyListenable(),
+          child: Container(),
+        ),
+      );
+
+      await tester.pumpWidget(
+        Provider.value(
+          value: MyStream(),
+          child: Container(),
+        ),
+      );
+    });
     test('cloneWithChild works', () {
       final provider = Provider.value(
         value: 42,

--- a/test/proxy_provider_test.dart
+++ b/test/proxy_provider_test.dart
@@ -48,6 +48,66 @@ void main() {
               Void, Void, Void, Combined>,
         );
 
+    testWidgets('throws if the provided value is a Listenable/Stream',
+        (tester) async {
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            Provider.value(value: a),
+            ProxyProvider<A, MyListenable>(
+              builder: (_, __, ___) => MyListenable(),
+            )
+          ],
+          child: Container(),
+        ),
+      );
+
+      expect(tester.takeException(), isFlutterError);
+
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            Provider.value(value: a),
+            ProxyProvider<A, MyStream>(
+              builder: (_, __, ___) => MyStream(),
+            )
+          ],
+          child: Container(),
+        ),
+      );
+
+      expect(tester.takeException(), isFlutterError);
+    });
+    testWidgets('debugCheckInvalidValueType can be disabled', (tester) async {
+      final previous = Provider.debugCheckInvalidValueType;
+      Provider.debugCheckInvalidValueType = null;
+      addTearDown(() => Provider.debugCheckInvalidValueType = previous);
+
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            Provider.value(value: a),
+            ProxyProvider<A, MyListenable>(
+              builder: (_, __, ___) => MyListenable(),
+            )
+          ],
+          child: Container(),
+        ),
+      );
+
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            Provider.value(value: a),
+            ProxyProvider<A, MyStream>(
+              builder: (_, __, ___) => MyStream(),
+            )
+          ],
+          child: Container(),
+        ),
+      );
+    });
+
     testWidgets('initialBuilder creates initial value', (tester) async {
       final initialBuilder = ValueBuilderMock<Combined>();
       final key = GlobalKey();


### PR DESCRIPTION
This is a health check to ensure that the listenable objects are indeed listened.

closes #102