### PR TITLE
Mobx integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - set -e # abort CI if an error happens
   - ./scripts/flutter_test.sh packages/provider
   - ./scripts/flutter_test.sh packages/provider/example
+  - ./scripts/flutter_test.sh packages/mobx_provider
 
   # export coverage
   - if [ $FLUTTER_CHANNEL = "stable" ]; then

--- a/packages/mobx_provider/.gitignore
+++ b/packages/mobx_provider/.gitignore
@@ -1,0 +1,14 @@
+# Files and directories created by pub
+.dart_tool/
+android/
+ios/
+.packages
+# Remove the following pattern if you wish to check in your lock file
+pubspec.lock
+
+# Conventional directory for build outputs
+build/
+coverage/
+
+# Directory created by dartdoc
+doc/api/

--- a/packages/mobx_provider/LICENSE
+++ b/packages/mobx_provider/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Remi Rousselet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mobx_provider/lib/mobx_provider.dart
+++ b/packages/mobx_provider/lib/mobx_provider.dart
@@ -1,0 +1,3 @@
+export 'package:provider/provider.dart' hide ProxyProvider;
+export 'src/store_provider.dart';
+export 'src/store_proxy_provider.dart';

--- a/packages/mobx_provider/lib/src/store_provider.dart
+++ b/packages/mobx_provider/lib/src/store_provider.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+import 'package:mobx/mobx.dart';
+
+class StoreProvider<T extends Store> extends ValueDelegateWidget<T>
+    implements SingleChildCloneableWidget {
+  StoreProvider({
+    Key key,
+    ValueBuilder<T> builder,
+    Widget child,
+  }) : this._(
+          key: key,
+          delegate: _StoreBuilderAdaptiveDelegate(builder),
+          child: child,
+        );
+
+  StoreProvider.value({
+    Key key,
+    T value,
+    UpdateShouldNotify<T> updateShouldNotify,
+    Widget child,
+  }) : this._(
+          key: key,
+          delegate: SingleValueDelegate(value),
+          updateShouldNotify: updateShouldNotify,
+          child: child,
+        );
+
+  StoreProvider._({
+    Key key,
+    ValueAdaptiveDelegate<T> delegate,
+    this.updateShouldNotify,
+    this.child,
+  }) : super(key: key, delegate: delegate);
+
+  final Widget child;
+  final UpdateShouldNotify<T> updateShouldNotify;
+
+  @override
+  Widget build(BuildContext context) {
+    return InheritedProvider<T>(
+      value: delegate.value,
+      updateShouldNotify: updateShouldNotify,
+      child: child,
+    );
+  }
+
+  @override
+  StoreProvider<T> cloneWithChild(Widget child) => StoreProvider<T>._(
+        key: key,
+        delegate: delegate,
+        updateShouldNotify: updateShouldNotify,
+        child: child,
+      );
+}
+
+class _StoreBuilderAdaptiveDelegate<T extends Store>
+    extends ValueAdaptiveDelegate<T> {
+  _StoreBuilderAdaptiveDelegate(this.builder);
+
+  final ValueBuilder<T> builder;
+
+  @override
+  T value;
+
+  @override
+  void initDelegate() {
+    value = builder(context);
+  }
+
+  @override
+  void didUpdateDelegate(_StoreBuilderAdaptiveDelegate<T> old) {
+    value = old.value;
+  }
+
+  @override
+  void dispose() {
+    value.dispose();
+  }
+}

--- a/packages/mobx_provider/lib/src/store_proxy_provider.dart
+++ b/packages/mobx_provider/lib/src/store_proxy_provider.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/widgets.dart';
+import 'package:mobx/mobx.dart';
+import 'package:mobx_provider/mobx_provider.dart';
+import 'package:provider/provider.dart';
+
+class ProxyProvider<T, R> extends ProxyProviderWidget
+    implements SingleChildCloneableWidget {
+  ProxyProvider({
+    Key key,
+    this.initialBuilder,
+    this.builder,
+    this.updateShouldNotify,
+    this.reactiveContext,
+    this.dispose,
+    this.child,
+  }) : super(key: key);
+
+  final ValueBuilder<R> initialBuilder;
+  final ProxyProviderBuilder<T, R> builder;
+  final UpdateShouldNotify<R> updateShouldNotify;
+  final ReactiveContext reactiveContext;
+  final Widget child;
+  final Disposer<R> dispose;
+
+  @override
+  _ProxyProviderState<T, R> createState() => _ProxyProviderState();
+
+  @override
+  ProxyProvider<T, R> cloneWithChild(Widget child) {
+    return ProxyProvider(
+      key: key,
+      initialBuilder: initialBuilder,
+      builder: builder,
+      updateShouldNotify: updateShouldNotify,
+      reactiveContext: reactiveContext,
+      dispose: dispose,
+      child: child,
+    );
+  }
+}
+
+class _ProxyProviderState<T, R>
+    extends ProxyProviderState<ProxyProvider<T, R>> {
+  ReactionDisposer _reactionDisposer;
+  ActionController controller;
+  R value;
+
+  @override
+  void initState() {
+    super.initState();
+    // TODO(rrousselGit) handle `reactiveContext` update
+    controller = ActionController(
+        context: widget.reactiveContext, name: 'ProxyProvider');
+    value = widget.initialBuilder?.call(context);
+  }
+
+  @override
+  void didUpdateDependencies() {
+    super.didUpdateDependencies();
+    _reactionDisposer?.call();
+    _reactionDisposer = autorun((_) {
+      setState(() {
+        final info = controller.startAction();
+        try {
+          value = widget.builder(context, Provider.of(context), value);
+        } finally {
+          controller.endAction(info);
+        }
+      });
+    }, onError: (err, _) {
+      FlutterError.reportError(FlutterErrorDetails(
+        library: 'mobx_provider',
+        exception: err,
+        context: ErrorDescription('ProxyProvider failed to call `builder`.'),
+      ));
+      // pipe to FlutterError
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InheritedProvider<R>(
+      value: value,
+      updateShouldNotify: widget.updateShouldNotify,
+      child: widget.child,
+    );
+  }
+
+  @override
+  void dispose() {
+    // called _before_ the dispose callback, as it may trigger the reaction again.
+    _reactionDisposer?.call();
+    widget.dispose?.call(context, value);
+    super.dispose();
+  }
+}

--- a/packages/mobx_provider/pubspec.yaml
+++ b/packages/mobx_provider/pubspec.yaml
@@ -1,0 +1,26 @@
+name: mobx_provider
+description: Helpers to simplify using "provider" and "mobx" together.
+version: 0.0.0
+homepage: https://github.com/rrousselGit/provider
+authors:
+  - Remi Rousselet <darky12s@gmail.com>
+environment:
+  sdk: ">=2.0.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  mobx:
+  flutter_mobx:
+
+dev_dependencies:
+  pedantic: ^1.4.0
+  mockito: ^4.0.0
+  flutter_test:
+    sdk: flutter
+  build_runner: ^1.3.1
+  mobx_codegen: ^0.2.0
+
+dependency_overrides:
+  provider:
+    path: ../provider

--- a/packages/mobx_provider/test/common.dart
+++ b/packages/mobx_provider/test/common.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/widgets.dart';
+import 'package:mobx/mobx.dart';
+import 'package:mockito/mockito.dart';
+
+part 'common.g.dart';
+
+class Counter = CounterBase with _$Counter;
+
+abstract class CounterBase with Store {
+  @observable
+  int value = 0;
+
+  @action
+  void increment() {
+    value++;
+  }
+}
+
+class FlutterErrorMock extends Mock {
+  void call(FlutterErrorDetails details);
+}
+
+class StoreMock extends Mock implements Store {}
+
+class DisposerMock<T> extends Mock {
+  void call(BuildContext context, T value);
+}
+
+class ReactiveContextMock extends Mock implements ReactiveContext {}

--- a/packages/mobx_provider/test/common.g.dart
+++ b/packages/mobx_provider/test/common.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'common.dart';
+
+// **************************************************************************
+// StoreGenerator
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, unnecessary_lambdas, prefer_expression_function_bodies, lines_longer_than_80_chars
+
+mixin _$Counter on CounterBase, Store {
+  final _$valueAtom = Atom(name: 'CounterBase.value');
+
+  @override
+  int get value {
+    _$valueAtom.reportObserved();
+    return super.value;
+  }
+
+  @override
+  set value(int value) {
+    _$valueAtom.context.checkIfStateModificationsAreAllowed(_$valueAtom);
+    super.value = value;
+    _$valueAtom.reportChanged();
+  }
+
+  final _$CounterBaseActionController = ActionController(name: 'CounterBase');
+
+  @override
+  void increment() {
+    final _$actionInfo = _$CounterBaseActionController.startAction();
+    try {
+      return super.increment();
+    } finally {
+      _$CounterBaseActionController.endAction(_$actionInfo);
+    }
+  }
+}

--- a/packages/mobx_provider/test/proxy_provider_test.dart
+++ b/packages/mobx_provider/test/proxy_provider_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobx_provider/mobx_provider.dart';
+import 'package:mockito/mockito.dart';
+
+import 'common.dart';
+
+class Foo extends StatelessWidget {
+  const Foo({Key key}) : this._(key: key);
+  const Foo._({Key key, this.children}) : super(key: key);
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: children);
+  }
+
+  Foo call(List<Widget> children) {
+    return Foo._(key: key, children: children);
+  }
+}
+
+void main() {
+  group('ProxyProvider', () {
+    testWidgets('report error to FlutterError', (tester) async {
+      final originOnError = FlutterError.onError;
+      var errorMock = FlutterErrorMock();
+      FlutterError.onError = errorMock;
+
+      final reactiveContext = ReactiveContextMock();
+      final error = Error();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [
+          Provider.value(value: 1),
+          ProxyProvider<int, Counter>(
+            reactiveContext: reactiveContext,
+            builder: (_, __, ___) => throw error,
+          ),
+        ],
+        child: Container(),
+      ));
+      FlutterError.onError = originOnError;
+
+      final verifyDetails = verify(errorMock(captureAny))..called(1);
+      final details = verifyDetails.captured.first as FlutterErrorDetails;
+
+      expect(details.exception, equals(error));
+      expect(details.library, equals('mobx_provider'));
+      verifyInOrder([
+        reactiveContext.startUntracked(),
+        reactiveContext.endUntracked(any),
+      ]);
+    });
+    testWidgets('disposes of the store', (tester) async {
+      final store = Counter();
+      final disposer = DisposerMock<Counter>();
+      final key = GlobalKey();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [
+          Provider.value(value: 1),
+          ProxyProvider<int, Counter>(
+            key: key,
+            builder: (_, __, ___) => store,
+            dispose: disposer,
+          ),
+        ],
+        child: Container(),
+      ));
+
+      verifyNoMoreInteractions(disposer);
+      final context = key.currentContext;
+
+      await tester.pumpWidget(Container());
+
+      verify(disposer(context, store)).called(1);
+      verifyNoMoreInteractions(disposer);
+    });
+    test('uses Proxy.debugCheckInvalidValueType', () {});
+    test('pass updateShouldNotify', () {});
+    testWidgets('works with MultiProvider', (tester) async {
+      final key = GlobalKey();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [
+          Provider.value(value: 42),
+          ProxyProvider<int, double>(builder: (c, a, p) => a.toDouble()),
+        ],
+        child: Container(key: key),
+      ));
+
+      expect(
+        Provider.of<double>(key.currentContext),
+        equals(42.0),
+      );
+    });
+    test('works with MultiProvider #2', () {
+      final provider = ProxyProvider<int, double>(
+        key: const Key('42'),
+        initialBuilder: (_) {},
+        builder: (_, __, ___) {},
+        updateShouldNotify: (_, __) {},
+        dispose: (_, __) {},
+        child: Container(),
+      );
+      var child2 = Container();
+      final clone = provider.cloneWithChild(child2);
+
+      expect(clone.child, equals(child2));
+      expect(clone.key, equals(provider.key));
+      expect(clone.initialBuilder, equals(provider.initialBuilder));
+      expect(clone.builder, equals(provider.builder));
+      expect(clone.updateShouldNotify, equals(provider.updateShouldNotify));
+      expect(clone.reactiveContext, equals(provider.reactiveContext));
+      expect(clone.dispose, equals(provider.dispose));
+    });
+
+    test('builder/initialbuilder called with proper arguments', () {});
+    testWidgets('smoke test', (tester) async {
+      var buildCount = 0;
+      final child = Observer(builder: (context) {
+        buildCount++;
+        return Text(
+          Provider.of<Counter>(context).value.toString(),
+          textDirection: TextDirection.ltr,
+        );
+      });
+      final store = Counter();
+
+      final provider = ProxyProvider<int, Counter>(
+        initialBuilder: (_) => store,
+        builder: (_, value, model) => model..value = value,
+      );
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [Provider.value(value: 1), provider],
+        child: child,
+      ));
+
+      expect(buildCount, equals(1));
+      expect(store.value, equals(1));
+      expect(find.text('1'), findsOneWidget);
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [Provider.value(value: 2), provider],
+        child: child,
+      ));
+
+      expect(store.value, equals(2));
+      expect(buildCount, equals(2));
+      expect(find.text('2'), findsOneWidget);
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [Provider.value(value: 2), provider],
+        child: child,
+      ));
+
+      expect(store.value, equals(2));
+      expect(buildCount, equals(2));
+      expect(find.text('2'), findsOneWidget);
+    });
+  });
+}

--- a/packages/mobx_provider/test/store_provider_test.dart
+++ b/packages/mobx_provider/test/store_provider_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobx_provider/mobx_provider.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mobx/mobx.dart' show Store;
+import 'package:provider/provider.dart';
+
+class StoreMock extends Mock implements Store {}
+
+void main() {
+  testWidgets('updateShouldNotify', (tester) async {
+    final updateShouldNotify = UpdateShouldNotifyMock<StoreMock>();
+    when(updateShouldNotify(any, any)).thenAnswer((invocation) {
+      return invocation.positionalArguments.first !=
+          invocation.positionalArguments.last;
+    });
+
+    var store = StoreMock();
+
+    var buildCount = 0;
+    final child = Builder(builder: (context) {
+      Provider.of<StoreMock>(context);
+      buildCount++;
+      return Container();
+    });
+
+    await tester.pumpWidget(StoreProvider.value(
+      value: store,
+      updateShouldNotify: updateShouldNotify,
+      child: child,
+    ));
+
+    verifyZeroInteractions(updateShouldNotify);
+    expect(buildCount, equals(1));
+
+    await tester.pumpWidget(StoreProvider.value(
+      value: store,
+      updateShouldNotify: updateShouldNotify,
+      child: child,
+    ));
+
+    expect(buildCount, equals(1));
+    verify(updateShouldNotify(store, store)).called(1);
+    verifyNoMoreInteractions(updateShouldNotify);
+
+    var store2 = StoreMock();
+    await tester.pumpWidget(StoreProvider.value(
+      value: store2,
+      updateShouldNotify: updateShouldNotify,
+      child: child,
+    ));
+
+    verify(updateShouldNotify(store, store2)).called(1);
+    verifyNoMoreInteractions(updateShouldNotify);
+    expect(buildCount, equals(2));
+  });
+  group('StoreProvider', () {
+    testWidgets('default ctor creates and dispose stores', (tester) async {
+      var store = StoreMock();
+      final builder = BuilderMock<StoreMock>();
+      final key = GlobalKey();
+
+      when(builder(any)).thenReturn(store);
+
+      await tester.pumpWidget(StoreProvider(
+        builder: builder,
+        child: Container(key: key),
+      ));
+
+      expect(Provider.of<StoreMock>(key.currentContext), equals(store));
+
+      await tester.pumpWidget(StoreProvider(
+        builder: builder,
+        child: Container(key: key),
+      ));
+
+      verifyZeroInteractions(store);
+
+      expect(Provider.of<StoreMock>(key.currentContext), equals(store));
+
+      await tester.pumpWidget(Container());
+
+      verify(store.dispose()).called(1);
+      verifyNoMoreInteractions(store);
+    });
+    testWidgets('works with MultiProvider', (tester) async {
+      final key = GlobalKey();
+      var store = StoreMock();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [
+          StoreProvider.value(value: store),
+        ],
+        child: Container(key: key),
+      ));
+
+      expect(Provider.of<StoreMock>(key.currentContext), store);
+    });
+    test('works with MultiProvider #2', () {
+      final provider = StoreProvider<Store>.value(
+        key: const Key('42'),
+        value: StoreMock(),
+        child: Container(),
+        updateShouldNotify: (_, __) {},
+      );
+      var child2 = Container();
+      final clone = provider.cloneWithChild(child2);
+
+      expect(clone.child, equals(child2));
+      expect(clone.key, equals(provider.key));
+      expect(clone.updateShouldNotify, equals(provider.updateShouldNotify));
+      expect(clone.delegate, equals(provider.delegate));
+    });
+    test('works with MultiProvider #3', () {
+      final provider = StoreProvider<StoreMock>(
+        builder: (_) => StoreMock(),
+        child: Container(),
+        key: const Key('42'),
+      );
+      var child2 = Container();
+      final clone = provider.cloneWithChild(child2);
+
+      expect(clone.child, equals(child2));
+      expect(clone.key, equals(provider.key));
+      expect(clone.updateShouldNotify, equals(provider.updateShouldNotify));
+      expect(clone.delegate, equals(provider.delegate));
+    });
+  });
+}
+
+class BuilderMock<T> extends Mock {
+  T call(BuildContext context);
+}
+
+class UpdateShouldNotifyMock<T> extends Mock {
+  bool call(T t1, T t2);
+}

--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -16,7 +16,7 @@
   These providers allows building values that depends on other providers,
   without loosing reactivity or manually handling the state.
 - Added `DelegateWidget` and a few related classes to help building custom providers.
-- Exposed the internal generic `InheritedWidget` to help building custom providers.
+- Exposed the internal generic `InheriteProvider` to help building custom providers.
 
 # 2.0.1
 

--- a/packages/provider/lib/provider.dart
+++ b/packages/provider/lib/provider.dart
@@ -6,5 +6,6 @@ export 'src/consumer.dart';
 export 'src/delegate_widget.dart';
 export 'src/listenable_provider.dart';
 export 'src/provider.dart';
-export 'src/proxy_provider.dart' hide NumericProxyProvider, Void;
+export 'src/proxy_provider.dart'
+    hide NumericProxyProvider, Void, ProxyProviderBase;
 export 'src/value_listenable_provider.dart';


### PR DESCRIPTION
This adds a mobx_provider package that defines mobx specific Providers. 

`mobx_provider` redifines existing proxy providers too, by wrapping the "builder" into a reaction+action. 

- [x] StoreProvider
- [ ] ProxyProvider
- [ ] StoreProxyProvider
- [ ] expose an overriden `debugCheckInvalidValueType` for stores.
- [ ] readme