### PR TITLE
fix clerical error for Consumer2

### DIFF
--- a/packages/provider/lib/src/consumer.dart
+++ b/packages/provider/lib/src/consumer.dart
@@ -68,7 +68,7 @@ class Consumer2<A, B> extends StatelessWidget {
   final Widget child;
 
   /// {@macro provider.consumer.builder}
-  final Widget Function(BuildContext context, A value, B value2, Widget chi)
+  final Widget Function(BuildContext context, A value, B value2, Widget child)
       builder;
 
   @override


### PR DESCRIPTION
fix a clerical error in the build function passing in the parameter
「chi」 => 「child」