### PR TITLE
Add state notifier

### DIFF
--- a/packages/provider/lib/src/state.dart
+++ b/packages/provider/lib/src/state.dart
@@ -1,0 +1,1 @@
+abstract class State {}

--- a/packages/provider/lib/src/state_notifier.dart
+++ b/packages/provider/lib/src/state_notifier.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/foundation.dart';
+
+abstract class StateNotifier<T> extends ChangeNotifier {
+  T _state;
+
+  StateNotifier() {
+    _state = initialState;
+  }
+
+  T get initialState;
+  T get state => _state;
+
+  void setState(T state) {
+    _state = state;
+    notifyListeners();
+  }
+}

--- a/packages/provider/pubspec.yaml
+++ b/packages/provider/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  equatable:
 
 dev_dependencies:
   pedantic: ^1.4.0


### PR DESCRIPTION
This is a concept for adding immutable state handling to provider. I'm not sure if you're intested in a changed like this, but wanted to propose before I put too much effort into making a nice PR :)

Please let me know if you think something like this would be useful and I can clean this up.

Another thought/step would be to add a `StateNotifierProvider` for Widgets to subscribe to state changes rather than the entire bloc `ChangeNotifier`.

```dart
class AuthenticationState extends State {
  final bool isLoading;
  final bool isAuthenticated;

  AuthenticationState({@required this.isLoading, @required this.isAuthenticated})
      : super([isLoading, isAuthenticated]);

  factory AuthenticationState.initial() {
    return AuthenticationState(isLoading: false, isAuthenticated: false);
  }

  factory AuthenticationState.loading() {
    return AuthenticationState(isLoading: true, isAuthenticated: false);
  }
}

class AuthenticationBloc extends StateNotifier<AuthenticationState> {
  AuthenticationBloc({@required this.session});

  logIn(String token) async {
    setState(AuthenticationState.loading());
    // do login stuff...
    setState(AuthenticationState(isLoading: f, isAuthenticated: false));
  }

  logOut() async {
    setState(AuthenticationState.loading());
    // do logout stuff.. 
    setState(AuthenticationState(isLoading: false, isAuthenticated: false));
  }

  @override
  AuthenticationState get initialState => AuthenticationState.initial();
}
```