### PR TITLE
new: make Consumer compatible with MultiProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ Provider<String>.value(
 );
 ```
 
+The widget `Consumer` can also be used inside `MultiProvider`. To do so,
+it must returns the `child` passed to `builder` in the wiget tree it creates.
+
+```dart
+MultiProvider(
+  providers: [
+    Provider(builder: (_) => Foo()),
+    Consumer<Foo>(
+      builder: (context, foo, child) =>
+        Provider.value(value: foo.bar, child: child),
+    )
+  ],
+);
+```
+
 ---
 
 Note that you can freely use multiple providers with different types together:

--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 3.1.0
+
+- `Consumer` can now be used inside `MultiProvider`
+  ```dart
+  MultiProvider(
+    providers: [
+      Provider(builder: (_) => Foo()),
+      Consumer<Foo>(
+        builder: (context, foo, child) =>
+          Provider.value(value: foo.bar, child: child),
+      )
+    ],
+  );
+  ```
+
 # 3.0.0
 
 ## breaking (see the readme for migration steps):

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -122,6 +122,21 @@ Provider<String>.value(
 );
 ```
 
+The widget `Consumer` can also be used inside `MultiProvider`. To do so,
+it must returns the `child` passed to `builder` in the wiget tree it creates.
+
+```dart
+MultiProvider(
+  providers: [
+    Provider(builder: (_) => Foo()),
+    Consumer<Foo>(
+      builder: (context, foo, child) =>
+        Provider.value(value: foo.bar, child: child),
+    )
+  ],
+);
+```
+
 ---
 
 Note that you can freely use multiple providers with different types together:

--- a/packages/provider/lib/src/consumer.dart
+++ b/packages/provider/lib/src/consumer.dart
@@ -7,11 +7,29 @@ import 'provider.dart';
 ///
 /// [builder] must not be null and may be called multiple times (such as when provided value change).
 ///
+/// #### Note:
+///
+/// The widget [Consumer] can also be used inside [MultiProvider]. To do so,
+/// it must returns the `child` passed to [builder] in the wiget tree it creates.
+///
+/// ```dart
+/// MultiProvider(
+///   providers: [
+///     Provider(builder: (_) => Foo()),
+///     Consumer<Foo>(
+///       builder: (context, foo, child) =>
+///         Provider.value(value: foo.bar, child: child),
+///     )
+///   ],
+/// );
+/// ```
+///
 /// ## Performance optimizations:
 ///
 /// {@macro provider.consumer.child}
 /// {@endtemplate}
-class Consumer<T> extends StatelessWidget {
+class Consumer<T> extends StatelessWidget
+    implements SingleChildCloneableWidget {
   /// {@template provider.consumer.constructor}
   /// Consumes a [Provider<T>]
   /// {@endtemplate}
@@ -50,10 +68,20 @@ class Consumer<T> extends StatelessWidget {
       child,
     );
   }
+
+  @override
+  Consumer<T> cloneWithChild(Widget child) {
+    return Consumer(
+      key: key,
+      builder: builder,
+      child: child,
+    );
+  }
 }
 
 /// {@macro provider.consumer}
-class Consumer2<A, B> extends StatelessWidget {
+class Consumer2<A, B> extends StatelessWidget
+    implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
   Consumer2({
     Key key,
@@ -80,10 +108,20 @@ class Consumer2<A, B> extends StatelessWidget {
       child,
     );
   }
+
+  @override
+  Consumer2<A, B> cloneWithChild(Widget child) {
+    return Consumer2(
+      key: key,
+      builder: builder,
+      child: child,
+    );
+  }
 }
 
 /// {@macro provider.consumer}
-class Consumer3<A, B, C> extends StatelessWidget {
+class Consumer3<A, B, C> extends StatelessWidget
+    implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
   Consumer3({
     Key key,
@@ -111,10 +149,20 @@ class Consumer3<A, B, C> extends StatelessWidget {
       child,
     );
   }
+
+  @override
+  Consumer3<A, B, C> cloneWithChild(Widget child) {
+    return Consumer3(
+      key: key,
+      builder: builder,
+      child: child,
+    );
+  }
 }
 
 /// {@macro provider.consumer}
-class Consumer4<A, B, C, D> extends StatelessWidget {
+class Consumer4<A, B, C, D> extends StatelessWidget
+    implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
   Consumer4({
     Key key,
@@ -142,10 +190,20 @@ class Consumer4<A, B, C, D> extends StatelessWidget {
       child,
     );
   }
+
+  @override
+  Consumer4<A, B, C, D> cloneWithChild(Widget child) {
+    return Consumer4(
+      key: key,
+      builder: builder,
+      child: child,
+    );
+  }
 }
 
 /// {@macro provider.consumer}
-class Consumer5<A, B, C, D, E> extends StatelessWidget {
+class Consumer5<A, B, C, D, E> extends StatelessWidget
+    implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
   Consumer5({
     Key key,
@@ -175,10 +233,20 @@ class Consumer5<A, B, C, D, E> extends StatelessWidget {
       child,
     );
   }
+
+  @override
+  Consumer5<A, B, C, D, E> cloneWithChild(Widget child) {
+    return Consumer5(
+      key: key,
+      builder: builder,
+      child: child,
+    );
+  }
 }
 
 /// {@macro provider.consumer}
-class Consumer6<A, B, C, D, E, F> extends StatelessWidget {
+class Consumer6<A, B, C, D, E, F> extends StatelessWidget
+    implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
   Consumer6({
     Key key,
@@ -207,6 +275,15 @@ class Consumer6<A, B, C, D, E, F> extends StatelessWidget {
       Provider.of<E>(context),
       Provider.of<F>(context),
       child,
+    );
+  }
+
+  @override
+  Consumer6<A, B, C, D, E, F> cloneWithChild(Widget child) {
+    return Consumer6(
+      key: key,
+      builder: builder,
+      child: child,
     );
   }
 }

--- a/packages/provider/pubspec.yaml
+++ b/packages/provider/pubspec.yaml
@@ -1,6 +1,6 @@
 name: provider
 description: A mixture between dependency injection and state management, built with widgets for widgets.
-version: 3.0.0+2
+version: 3.1.0
 homepage: https://github.com/rrousselGit/provider
 authors:
   - Remi Rousselet <darky12s@gmail.com>

--- a/packages/provider/test/consumer_test.dart
+++ b/packages/provider/test/consumer_test.dart
@@ -85,6 +85,22 @@ void main() {
         throwsAssertionError,
       );
     });
+    testWidgets('can be used inside MultiProvider', (tester) async {
+      final key = GlobalKey();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: List.from(provider.providers)
+          ..add(Consumer<A>(
+            key: key,
+            builder: (_, a, child) => Container(child: child),
+          )),
+        child: const Text('foo', textDirection: TextDirection.ltr),
+      ));
+
+      expect(find.text('foo'), findsOneWidget);
+      expect(find.byType(Container), findsOneWidget);
+      expect(key.currentContext, isNotNull);
+    });
   });
 
   group('consumer2', () {
@@ -111,6 +127,23 @@ void main() {
         throwsAssertionError,
       );
     });
+
+    testWidgets('can be used inside MultiProvider', (tester) async {
+      final key = GlobalKey();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: List.from(provider.providers)
+          ..add(Consumer2<A, B>(
+            key: key,
+            builder: (_, a, b, child) => Container(child: child),
+          )),
+        child: const Text('foo', textDirection: TextDirection.ltr),
+      ));
+
+      expect(find.text('foo'), findsOneWidget);
+      expect(find.byType(Container), findsOneWidget);
+      expect(key.currentContext, isNotNull);
+    });
   });
   group('consumer3', () {
     testWidgets('obtains value from Provider<T>', (tester) async {
@@ -135,6 +168,23 @@ void main() {
         () => Consumer3<A, B, C>(builder: null),
         throwsAssertionError,
       );
+    });
+
+    testWidgets('can be used inside MultiProvider', (tester) async {
+      final key = GlobalKey();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: List.from(provider.providers)
+          ..add(Consumer3<A, B, C>(
+            key: key,
+            builder: (_, a, b, c, child) => Container(child: child),
+          )),
+        child: const Text('foo', textDirection: TextDirection.ltr),
+      ));
+
+      expect(find.text('foo'), findsOneWidget);
+      expect(find.byType(Container), findsOneWidget);
+      expect(key.currentContext, isNotNull);
     });
   });
   group('consumer4', () {
@@ -161,6 +211,23 @@ void main() {
         throwsAssertionError,
       );
     });
+
+    testWidgets('can be used inside MultiProvider', (tester) async {
+      final key = GlobalKey();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: List.from(provider.providers)
+          ..add(Consumer4<A, B, C, D>(
+            key: key,
+            builder: (_, a, b, c, d, child) => Container(child: child),
+          )),
+        child: const Text('foo', textDirection: TextDirection.ltr),
+      ));
+
+      expect(find.text('foo'), findsOneWidget);
+      expect(find.byType(Container), findsOneWidget);
+      expect(key.currentContext, isNotNull);
+    });
   });
   group('consumer5', () {
     testWidgets('obtains value from Provider<T>', (tester) async {
@@ -186,6 +253,23 @@ void main() {
         throwsAssertionError,
       );
     });
+
+    testWidgets('can be used inside MultiProvider', (tester) async {
+      final key = GlobalKey();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: List.from(provider.providers)
+          ..add(Consumer5<A, B, C, D, E>(
+            key: key,
+            builder: (_, a, b, c, d, e, child) => Container(child: child),
+          )),
+        child: const Text('foo', textDirection: TextDirection.ltr),
+      ));
+
+      expect(find.text('foo'), findsOneWidget);
+      expect(find.byType(Container), findsOneWidget);
+      expect(key.currentContext, isNotNull);
+    });
   });
   group('consumer6', () {
     testWidgets('obtains value from Provider<T>', (tester) async {
@@ -210,6 +294,23 @@ void main() {
         () => Consumer6<A, B, C, D, E, F>(builder: null),
         throwsAssertionError,
       );
+    });
+
+    testWidgets('can be used inside MultiProvider', (tester) async {
+      final key = GlobalKey();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: List.from(provider.providers)
+          ..add(Consumer6<A, B, C, D, E, F>(
+            key: key,
+            builder: (_, a, b, c, d, e, f, child) => Container(child: child),
+          )),
+        child: const Text('foo', textDirection: TextDirection.ltr),
+      ));
+
+      expect(find.text('foo'), findsOneWidget);
+      expect(find.byType(Container), findsOneWidget);
+      expect(key.currentContext, isNotNull);
     });
   });
 }


### PR DESCRIPTION
Since `Consumer` already takes an optional `child` argument that is passed to `builder`, `Consumer` can be made compatible with `MultiProvider`.

It can be useful for simple scenarios where a `ProxyProvider` doesn't exist but `Provider.of(context, listen: false)` is not possible:

```dart
MultiProvider(
  providers: [
    ChangeNotifierProvider(builder: (_) => Foo()),
    Consumer(
      builder: (_, foo, child) => FutureProvider.value(value: foo.future, child: child),
    ),
  ],
);
```