### PR TITLE
Check AsyncSnapshot.hasData

### DIFF
--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.1
+
+- Updates for https://github.com/flutter/flutter/issues/34545
+
 # 3.1.0
 
 - `Consumer` can now be used inside `MultiProvider`

--- a/packages/provider/lib/src/async_provider.dart
+++ b/packages/provider/lib/src/async_provider.dart
@@ -136,7 +136,7 @@ class StreamProvider<T> extends ValueDelegateWidget<Stream<T>>
   Widget build(BuildContext context) {
     return StreamBuilder<T>(
       stream: delegate.value,
-      initialData: initialData,
+      initialData: initialData, // ignore: deprecated_member_use
       builder: (_, snapshot) {
         return InheritedProvider<T>(
           value: _snapshotToValue(snapshot, context, catchError, this),
@@ -164,7 +164,7 @@ Exception:
 ${snapshot.error}
 ''');
   }
-  return snapshot.data;
+  return snapshot.hasData ? snapshot.data : null;
 }
 
 class _StreamControllerBuilderDelegate<T>
@@ -172,7 +172,7 @@ class _StreamControllerBuilderDelegate<T>
   _StreamControllerBuilderDelegate(this._builder) : assert(_builder != null);
 
   StreamController<T> _controller;
-  ValueBuilder<StreamController<T>> _builder;
+  final ValueBuilder<StreamController<T>> _builder;
 
   @override
   Stream<T> value;
@@ -293,7 +293,7 @@ class FutureProvider<T> extends ValueDelegateWidget<Future<T>>
   Widget build(BuildContext context) {
     return FutureBuilder<T>(
       future: delegate.value,
-      initialData: initialData,
+      initialData: initialData, // ignore: deprecated_member_use
       builder: (_, snapshot) {
         return InheritedProvider<T>(
           value: _snapshotToValue(snapshot, context, catchError, this),

--- a/packages/provider/pubspec.yaml
+++ b/packages/provider/pubspec.yaml
@@ -1,6 +1,6 @@
 name: provider
 description: A mixture between dependency injection and state management, built with widgets for widgets.
-version: 3.1.0
+version: 3.1.1
 homepage: https://github.com/rrousselGit/provider
 authors:
   - Remi Rousselet <darky12s@gmail.com>


### PR DESCRIPTION
This updates the retrieval of `AsyncSnapshot.data` to first
check `AsyncSnapshot.hasData`, in accordance with the guidance
laid out by https://github.com/flutter/flutter/issues/34545