### PR TITLE
Mark constructors on @immutable classes as const

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -55,6 +55,7 @@ linter:
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
     - prefer_contains
     - prefer_equal_for_default_values
     - prefer_final_fields

--- a/packages/provider/lib/src/async_provider.dart
+++ b/packages/provider/lib/src/async_provider.dart
@@ -98,7 +98,7 @@ class StreamProvider<T> extends ValueDelegateWidget<Stream<T>>
           child: child,
         );
 
-  StreamProvider._({
+  const StreamProvider._({
     Key key,
     @required ValueStateDelegate<Stream<T>> delegate,
     this.initialData,
@@ -253,7 +253,7 @@ class FutureProvider<T> extends ValueDelegateWidget<Future<T>>
           child: child,
         );
 
-  FutureProvider._({
+  const FutureProvider._({
     Key key,
     @required ValueStateDelegate<Future<T>> delegate,
     this.initialData,

--- a/packages/provider/lib/src/change_notifier_provider.dart
+++ b/packages/provider/lib/src/change_notifier_provider.dart
@@ -196,7 +196,7 @@ class ChangeNotifierProvider<T extends ChangeNotifier>
 class ChangeNotifierProxyProvider<T, R extends ChangeNotifier>
     extends ListenableProxyProvider<T, R> {
   /// Initializes [key] for subclasses.
-  ChangeNotifierProxyProvider({
+  const ChangeNotifierProxyProvider({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder<T, R> builder,
@@ -214,7 +214,7 @@ class ChangeNotifierProxyProvider<T, R extends ChangeNotifier>
 class ChangeNotifierProxyProvider2<T, T2, R extends ChangeNotifier>
     extends ListenableProxyProvider2<T, T2, R> {
   /// Initializes [key] for subclasses.
-  ChangeNotifierProxyProvider2({
+  const ChangeNotifierProxyProvider2({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder2<T, T2, R> builder,
@@ -232,7 +232,7 @@ class ChangeNotifierProxyProvider2<T, T2, R extends ChangeNotifier>
 class ChangeNotifierProxyProvider3<T, T2, T3, R extends ChangeNotifier>
     extends ListenableProxyProvider3<T, T2, T3, R> {
   /// Initializes [key] for subclasses.
-  ChangeNotifierProxyProvider3({
+  const ChangeNotifierProxyProvider3({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder3<T, T2, T3, R> builder,
@@ -250,7 +250,7 @@ class ChangeNotifierProxyProvider3<T, T2, T3, R extends ChangeNotifier>
 class ChangeNotifierProxyProvider4<T, T2, T3, T4, R extends ChangeNotifier>
     extends ListenableProxyProvider4<T, T2, T3, T4, R> {
   /// Initializes [key] for subclasses.
-  ChangeNotifierProxyProvider4({
+  const ChangeNotifierProxyProvider4({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder4<T, T2, T3, T4, R> builder,
@@ -269,7 +269,7 @@ class ChangeNotifierProxyProvider4<T, T2, T3, T4, R extends ChangeNotifier>
 class ChangeNotifierProxyProvider5<T, T2, T3, T4, T5, R extends ChangeNotifier>
     extends ListenableProxyProvider5<T, T2, T3, T4, T5, R> {
   /// Initializes [key] for subclasses.
-  ChangeNotifierProxyProvider5({
+  const ChangeNotifierProxyProvider5({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder5<T, T2, T3, T4, T5, R> builder,
@@ -288,7 +288,7 @@ class ChangeNotifierProxyProvider6<T, T2, T3, T4, T5, T6,
         R extends ChangeNotifier>
     extends ListenableProxyProvider6<T, T2, T3, T4, T5, T6, R> {
   /// Initializes [key] for subclasses.
-  ChangeNotifierProxyProvider6({
+  const ChangeNotifierProxyProvider6({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder6<T, T2, T3, T4, T5, T6, R> builder,

--- a/packages/provider/lib/src/consumer.dart
+++ b/packages/provider/lib/src/consumer.dart
@@ -158,7 +158,7 @@ class Consumer<T> extends StatelessWidget
   /// {@template provider.consumer.constructor}
   /// Consumes a [Provider<T>]
   /// {@endtemplate}
-  Consumer({
+  const Consumer({
     Key key,
     @required this.builder,
     this.child,
@@ -198,7 +198,7 @@ class Consumer<T> extends StatelessWidget
 class Consumer2<A, B> extends StatelessWidget
     implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
-  Consumer2({
+  const Consumer2({
     Key key,
     @required this.builder,
     this.child,
@@ -236,7 +236,7 @@ class Consumer2<A, B> extends StatelessWidget
 class Consumer3<A, B, C> extends StatelessWidget
     implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
-  Consumer3({
+  const Consumer3({
     Key key,
     @required this.builder,
     this.child,
@@ -275,7 +275,7 @@ class Consumer3<A, B, C> extends StatelessWidget
 class Consumer4<A, B, C, D> extends StatelessWidget
     implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
-  Consumer4({
+  const Consumer4({
     Key key,
     @required this.builder,
     this.child,
@@ -314,7 +314,7 @@ class Consumer4<A, B, C, D> extends StatelessWidget
 class Consumer5<A, B, C, D, E> extends StatelessWidget
     implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
-  Consumer5({
+  const Consumer5({
     Key key,
     @required this.builder,
     this.child,
@@ -355,7 +355,7 @@ class Consumer5<A, B, C, D, E> extends StatelessWidget
 class Consumer6<A, B, C, D, E, F> extends StatelessWidget
     implements SingleChildCloneableWidget {
   /// {@macro provider.consumer.constructor}
-  Consumer6({
+  const Consumer6({
     Key key,
     @required this.builder,
     this.child,

--- a/packages/provider/lib/src/delegate_widget.dart
+++ b/packages/provider/lib/src/delegate_widget.dart
@@ -272,7 +272,7 @@ abstract class ValueDelegateWidget<T> extends DelegateWidget {
   /// Initializes [key] for subclasses.
   ///
   /// The argument [delegate] must not be `null`.
-  ValueDelegateWidget({
+  const ValueDelegateWidget({
     Key key,
     @required ValueStateDelegate<T> delegate,
   }) : super(key: key, delegate: delegate);

--- a/packages/provider/lib/src/listenable_provider.dart
+++ b/packages/provider/lib/src/listenable_provider.dart
@@ -57,7 +57,7 @@ class ListenableProvider<T extends Listenable> extends ValueDelegateWidget<T>
           child: child,
         );
 
-  ListenableProvider._({
+  const ListenableProvider._({
     Key key,
     @required _ListenableDelegateMixin<T> delegate,
     // ignore: lines_longer_than_80_chars
@@ -212,7 +212,7 @@ ChangeNotifierProvider(
 
 class _NumericProxyProvider<T, T2, T3, T4, T5, T6, R extends Listenable>
     extends ProxyProviderBase<R> implements SingleChildCloneableWidget {
-  _NumericProxyProvider({
+  const _NumericProxyProvider({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required this.builder,
@@ -289,7 +289,7 @@ class _NumericProxyProvider<T, T2, T3, T4, T5, T6, R extends Listenable>
 class ListenableProxyProvider<T, R extends Listenable>
     extends _NumericProxyProvider<T, Void, Void, Void, Void, Void, R> {
   /// Initializes [key] for subclasses.
-  ListenableProxyProvider({
+  const ListenableProxyProvider({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder<T, R> builder,
@@ -312,7 +312,7 @@ class ListenableProxyProvider<T, R extends Listenable>
 class ListenableProxyProvider2<T, T2, R extends Listenable>
     extends _NumericProxyProvider<T, T2, Void, Void, Void, Void, R> {
   /// Initializes [key] for subclasses.
-  ListenableProxyProvider2({
+  const ListenableProxyProvider2({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder2<T, T2, R> builder,
@@ -335,7 +335,7 @@ class ListenableProxyProvider2<T, T2, R extends Listenable>
 class ListenableProxyProvider3<T, T2, T3, R extends Listenable>
     extends _NumericProxyProvider<T, T2, T3, Void, Void, Void, R> {
   /// Initializes [key] for subclasses.
-  ListenableProxyProvider3({
+  const ListenableProxyProvider3({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder3<T, T2, T3, R> builder,
@@ -358,7 +358,7 @@ class ListenableProxyProvider3<T, T2, T3, R extends Listenable>
 class ListenableProxyProvider4<T, T2, T3, T4, R extends Listenable>
     extends _NumericProxyProvider<T, T2, T3, T4, Void, Void, R> {
   /// Initializes [key] for subclasses.
-  ListenableProxyProvider4({
+  const ListenableProxyProvider4({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder4<T, T2, T3, T4, R> builder,
@@ -381,7 +381,7 @@ class ListenableProxyProvider4<T, T2, T3, T4, R extends Listenable>
 class ListenableProxyProvider5<T, T2, T3, T4, T5, R extends Listenable>
     extends _NumericProxyProvider<T, T2, T3, T4, T5, Void, R> {
   /// Initializes [key] for subclasses.
-  ListenableProxyProvider5({
+  const ListenableProxyProvider5({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder5<T, T2, T3, T4, T5, R> builder,
@@ -404,7 +404,7 @@ class ListenableProxyProvider5<T, T2, T3, T4, T5, R extends Listenable>
 class ListenableProxyProvider6<T, T2, T3, T4, T5, T6, R extends Listenable>
     extends _NumericProxyProvider<T, T2, T3, T4, T5, T6, R> {
   /// Initializes [key] for subclasses.
-  ListenableProxyProvider6({
+  const ListenableProxyProvider6({
     Key key,
     @required ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder6<T, T2, T3, T4, T5, T6, R> builder,

--- a/packages/provider/lib/src/provider.dart
+++ b/packages/provider/lib/src/provider.dart
@@ -235,7 +235,7 @@ class Provider<T> extends ValueDelegateWidget<T>
           child: child,
         );
 
-  Provider._({
+  const Provider._({
     Key key,
     @required ValueStateDelegate<T> delegate,
     this.updateShouldNotify,

--- a/packages/provider/lib/src/proxy_provider.dart
+++ b/packages/provider/lib/src/proxy_provider.dart
@@ -111,7 +111,7 @@ abstract class Void {}
 /// See [ProxyProvider] for a concrete implementation.
 abstract class ProxyProviderBase<R> extends ProxyProviderWidget {
   /// Initializes [key], [initialBuilder] and [dispose] for subclasses.
-  ProxyProviderBase({
+  const ProxyProviderBase({
     Key key,
     this.initialBuilder,
     this.dispose,
@@ -179,7 +179,7 @@ class _ProxyProviderState<R> extends ProxyProviderState<ProxyProviderBase<R>> {
 class NumericProxyProvider<T, T2, T3, T4, T5, T6, R>
     extends ProxyProviderBase<R> implements SingleChildCloneableWidget {
   // ignore: public_member_api_docs
-  NumericProxyProvider({
+  const NumericProxyProvider({
     Key key,
     ValueBuilder<R> initialBuilder,
     @required this.builder,
@@ -322,7 +322,7 @@ class NumericProxyProvider<T, T2, T3, T4, T5, T6, R>
 class ProxyProvider<T, R>
     extends NumericProxyProvider<T, Void, Void, Void, Void, Void, R> {
   /// Initializes [key] for subclasses.
-  ProxyProvider({
+  const ProxyProvider({
     Key key,
     ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder<T, R> builder,
@@ -347,7 +347,7 @@ class ProxyProvider<T, R>
 class ProxyProvider2<T, T2, R>
     extends NumericProxyProvider<T, T2, Void, Void, Void, Void, R> {
   /// Initializes [key] for subclasses.
-  ProxyProvider2({
+  const ProxyProvider2({
     Key key,
     ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder2<T, T2, R> builder,
@@ -372,7 +372,7 @@ class ProxyProvider2<T, T2, R>
 class ProxyProvider3<T, T2, T3, R>
     extends NumericProxyProvider<T, T2, T3, Void, Void, Void, R> {
   /// Initializes [key] for subclasses.
-  ProxyProvider3({
+  const ProxyProvider3({
     Key key,
     ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder3<T, T2, T3, R> builder,
@@ -397,7 +397,7 @@ class ProxyProvider3<T, T2, T3, R>
 class ProxyProvider4<T, T2, T3, T4, R>
     extends NumericProxyProvider<T, T2, T3, T4, Void, Void, R> {
   /// Initializes [key] for subclasses.
-  ProxyProvider4({
+  const ProxyProvider4({
     Key key,
     ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder4<T, T2, T3, T4, R> builder,
@@ -422,7 +422,7 @@ class ProxyProvider4<T, T2, T3, T4, R>
 class ProxyProvider5<T, T2, T3, T4, T5, R>
     extends NumericProxyProvider<T, T2, T3, T4, T5, Void, R> {
   /// Initializes [key] for subclasses.
-  ProxyProvider5({
+  const ProxyProvider5({
     Key key,
     ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder5<T, T2, T3, T4, T5, R> builder,
@@ -447,7 +447,7 @@ class ProxyProvider5<T, T2, T3, T4, T5, R>
 class ProxyProvider6<T, T2, T3, T4, T5, T6, R>
     extends NumericProxyProvider<T, T2, T3, T4, T5, T6, R> {
   /// Initializes [key] for subclasses.
-  ProxyProvider6({
+  const ProxyProvider6({
     Key key,
     ValueBuilder<R> initialBuilder,
     @required ProxyProviderBuilder6<T, T2, T3, T4, T5, T6, R> builder,

--- a/packages/provider/lib/src/selector.dart
+++ b/packages/provider/lib/src/selector.dart
@@ -27,7 +27,7 @@ import 'delegate_widget.dart';
 class Selector0<T> extends StatefulWidget
     implements SingleChildCloneableWidget {
   /// Both `builder` and `selector` must not be `null`.
-  Selector0({
+  const Selector0({
     Key key,
     @required this.builder,
     @required this.selector,

--- a/packages/provider/lib/src/value_listenable_provider.dart
+++ b/packages/provider/lib/src/value_listenable_provider.dart
@@ -61,7 +61,7 @@ class ValueListenableProvider<T> extends ValueDelegateWidget<ValueListenable<T>>
           child: child,
         );
 
-  ValueListenableProvider._({
+  const ValueListenableProvider._({
     Key key,
     @required ValueStateDelegate<ValueListenable<T>> delegate,
     this.updateShouldNotify,

--- a/packages/provider/test/delegate_widget_test.dart
+++ b/packages/provider/test/delegate_widget_test.dart
@@ -341,7 +341,7 @@ class MockStateDelegate<T> extends StateDelegate {
 
 class BuilderDelegateWidget<T extends ValueStateDelegate<dynamic>>
     extends ValueDelegateWidget<dynamic> {
-  BuilderDelegateWidget({Key key, this.builder, T delegate})
+  const BuilderDelegateWidget({Key key, this.builder, T delegate})
       : super(key: key, delegate: delegate);
 
   final Widget Function(BuildContext context, T delegate) builder;
@@ -351,7 +351,7 @@ class BuilderDelegateWidget<T extends ValueStateDelegate<dynamic>>
 }
 
 class TestDelegateWidget extends DelegateWidget {
-  TestDelegateWidget({Key key, this.child, StateDelegate delegate})
+  const TestDelegateWidget({Key key, this.child, StateDelegate delegate})
       : super(key: key, delegate: delegate);
 
   final Widget child;


### PR DESCRIPTION
Most of the provided classes are immutable so we can mark the constructors as `const`