### PR TITLE
Using context.dependOnInheritedWidgetOfExactType instead context.inheritFromWidgetOfExactType

### DIFF
--- a/packages/provider/lib/src/delegate_widget.dart
+++ b/packages/provider/lib/src/delegate_widget.dart
@@ -168,15 +168,24 @@ class _DelegateElement extends StatefulElement {
   @override
   DelegateWidget get widget => super.widget as DelegateWidget;
 
+  @Deprecated(
+    'Use dependOnInheritedWidgetOfExactType instead. '
+    'This feature was deprecated after v1.12.1.',
+  )
   @override
   InheritedWidget inheritFromElement(Element ancestor, {Object aspect}) {
+    return dependOnInheritedElement(ancestor, aspect: aspect);
+  }
+
+  @override
+  InheritedWidget dependOnInheritedElement(Element ancestor, {Object aspect}) {
     assert(() {
       if (_debugIsInitDelegate) {
         final targetType = ancestor.widget.runtimeType;
         // error copied from StatefulElement
         throw FlutterError('''
-inheritFromWidgetOfExactType($targetType) or inheritFromElement() was called
-before ${widget.delegate.runtimeType}.initDelegate() completed.
+dependOnInheritedWidgetOfExactType<$targetType>() or dependOnInheritedElement()
+was called before ${widget.delegate.runtimeType}.initDelegate() completed.
 
 When an inherited widget changes, for example if the value of Theme.of()
 changes, its dependent widgets are rebuilt. If the dependent widget's reference
@@ -191,7 +200,7 @@ whenever the dependencies change thereafter.''');
       }
       return true;
     }());
-    return super.inheritFromElement(ancestor, aspect: aspect);
+    return super.dependOnInheritedElement(ancestor, aspect: aspect);
   }
 }
 

--- a/packages/provider/lib/src/provider.dart
+++ b/packages/provider/lib/src/provider.dart
@@ -253,12 +253,11 @@ class Provider<T> extends ValueDelegateWidget<T>
   /// [State.build] to widgets, and [State.didChangeDependencies] for
   /// [StatefulWidget].
   static T of<T>(BuildContext context, {bool listen = true}) {
-    // this is required to get generic Type
-    final type = _typeOf<InheritedProvider<T>>();
     final provider = listen
-        ? context.inheritFromWidgetOfExactType(type) as InheritedProvider<T>
-        : context.ancestorInheritedElementForWidgetOfExactType(type)?.widget
-            as InheritedProvider<T>;
+        ? context.dependOnInheritedWidgetOfExactType<InheritedProvider<T>>()
+        : context
+            .getElementForInheritedWidgetOfExactType<InheritedProvider<T>>()
+            ?.widget as InheritedProvider<T>;
 
     if (provider == null) {
       throw ProviderNotFoundError(T, context.widget.runtimeType);

--- a/packages/provider/test/delegate_widget_test.dart
+++ b/packages/provider/test/delegate_widget_test.dart
@@ -12,7 +12,7 @@ void main() {
   group('DelegateWidget', () {
     testWidgets(
         // ignore: lines_longer_than_80_chars
-        "can't call context.inheritFromWidgetOfExactType from first initDelegate",
+        "can't call context.dependOnInheritedWidgetOfExactType from first initDelegate",
         (tester) async {
       await tester.pumpWidget(Provider.value(
         value: 42,
@@ -26,7 +26,7 @@ void main() {
     });
     testWidgets(
         // ignore: lines_longer_than_80_chars
-        "can't call context.inheritFromWidgetOfExactType from initDelegate after an update",
+        "can't call context.dependOnInheritedWidgetOfExactType from initDelegate after an update",
         (tester) async {
       await tester.pumpWidget(Provider.value(
         value: 42,


### PR DESCRIPTION
`Provider` use `_DelegateElement` and every custom element must have the same api of `Element`, then the following actions were done:

- Updated `_DelegateElement` deprecating `inheritFromElement` in favor of `inheritFromElement`.
- Updated static Provider.of
```
final provider = listen
        ? context.dependOnInheritedWidgetOfExactType<InheritedProvider<T>>()
        : context
            .getElementForInheritedWidgetOfExactType<InheritedProvider<T>>()
            ?.widget as InheritedProvider<T>;
```