### PR TITLE
Remove indication to always use package imports

### DIFF
--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -309,7 +309,6 @@ To fix, please:
   * Provide types to Provider<$valueType>
   * Provide types to Consumer<$valueType>
   * Provide types to Provider.of<$valueType>()
-  * Always use package imports. Ex: `import 'package:my_app/my_code.dart';
   * Ensure the correct `context` is being used.
 
 If none of these solutions work, please file a bug at:

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -304,7 +304,6 @@ To fix, please:
   * Provide types to Provider<String>
   * Provide types to Consumer<String>
   * Provide types to Provider.of<String>()
-  * Always use package imports. Ex: `import 'package:my_app/my_code.dart';
   * Ensure the correct `context` is being used.
 
 If none of these solutions work, please file a bug at:


### PR DESCRIPTION
As mentioned in [this stackoverflow answer](https://stackoverflow.com/a/60184880/10122791), the indication to always use package imports is now obsolete as the mentioned bug from Dart does not exist anymore.

Closes #345 