### PR TITLE
Fix ChangeNotifierProvider builder argument

### DIFF
--- a/lib/src/inherited_provider.dart
+++ b/lib/src/inherited_provider.dart
@@ -123,8 +123,13 @@ class InheritedProvider<T> extends SingleChildStatelessWidget {
 
   @override
   Widget buildWithChild(BuildContext context, Widget child) {
-    assert(child != null,
-        '$runtimeType used outside of MultiProvider must specify a child');
+    assert(() {
+      if (_builder == null && child == null) {
+        throw AssertionError(
+            '$runtimeType used outside of MultiProvider must specify a child');
+      }
+      return true;
+    }());
     return _InheritedProviderScope<T>(
       owner: this,
       child: _builder != null

--- a/test/change_notifier_provider_test.dart
+++ b/test/change_notifier_provider_test.dart
@@ -321,4 +321,32 @@ void main() {
       expect(myNotifier.notifyListeners, throwsAssertionError);
     });
   });
+
+  testWidgets('Use builder property, not child', (tester) async {
+    final myNotifier = ValueNotifier<int>(0);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ValueNotifier<int>>(
+        create: (context) => myNotifier,
+        builder: (context, _) {
+          final notifier = context.watch<ValueNotifier<int>>();
+          return Text(
+            '${notifier.value}',
+            textDirection: TextDirection.ltr,
+          );
+        },
+      ),
+    );
+
+    expect(find.text('0'), findsOneWidget);
+
+    myNotifier.value++;
+    await tester.pump();
+
+    expect(find.text('1'), findsOneWidget);
+
+    await tester.pumpWidget(Container());
+
+    expect(myNotifier.notifyListeners, throwsAssertionError);
+  });
 }

--- a/test/inherited_provider_test.dart
+++ b/test/inherited_provider_test.dart
@@ -459,7 +459,7 @@ The context used was: Context
       isA<AssertionError>().having(
         (source) => source.toString(),
         'toString',
-        endsWith(
+        contains(
             'InheritedProvider<int> used outside of MultiProvider must specify a child'),
       ),
     );
@@ -479,7 +479,7 @@ The context used was: Context
       isA<AssertionError>().having(
         (source) => source.toString(),
         'toString',
-        endsWith(
+        contains(
             'InheritedProvider<int> used outside of MultiProvider must specify a child'),
       ),
     );
@@ -502,7 +502,7 @@ The context used was: Context
       isA<AssertionError>().having(
         (source) => source.toString(),
         'toString',
-        endsWith(
+        contains(
             'DeferredInheritedProvider<int, int> used outside of MultiProvider must specify a child'),
       ),
     );
@@ -525,7 +525,7 @@ The context used was: Context
       isA<AssertionError>().having(
         (source) => source.toString(),
         'toString',
-        endsWith(
+        contains(
             'DeferredInheritedProvider<int, int> used outside of MultiProvider must specify a child'),
       ),
     );


### PR DESCRIPTION
Fixes a regression which forces users of `ChangeNotifierProvider` to provide a `child` even if a `builder` is provided.

```dart
// AssertionError: ChangeNotifierProvider<GoodsListModel> used outside of MultiProvider must specify a child
ChangeNotifierProvider(
  create: (_) => GoodsListModel(),
  builder: _buildGoodsListView,
),
```

Fixes #442 
