### PR TITLE
Updates the comment doc  of the `ProxyProvider`

### DIFF
--- a/lib/src/proxy_provider.dart
+++ b/lib/src/proxy_provider.dart
@@ -109,7 +109,7 @@ class ProxyProvider0<R> extends InheritedProvider<R> {
 /// ProxyProvider0<Result>(
 ///   update: (context, result) {
 ///     final a = Provider.of<A>(context);
-///     return update(context, a, b, result);
+///     return update(context, a, result);
 ///   }
 /// );
 /// ```


### PR DESCRIPTION
In the comment, the `return update(context, a, b, result)` for `ProxyProvider<A, Result>` has a extra parameter, which is the `b`. It's  should not appear here.