### PR TITLE
Fix invalid link in the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,4 +290,4 @@ Fixed typo in the error message of `ProviderNotFoundException`
 - `onDispose` has been added to `StatefulProvider`
 - [BuildContext] is now passed to `valueBuilder` callback
 
-[BuildContext]: (https://api.flutter.dev/flutter/widgets/BuildContext-class.html)
+[BuildContext]: https://api.flutter.dev/flutter/widgets/BuildContext-class.html


### PR DESCRIPTION
[pub.dev](https://pub.dev/packages/provider/score) complains about an invalid changelog file:

![image](https://user-images.githubusercontent.com/720821/91762440-a65e9800-ebd5-11ea-9021-7ae0f5d7578d.png)

Looks like there is no need to include parentheses: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links.