### PR TITLE
Remove unused dart:async import

### DIFF
--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core