### PR TITLE
Multiprovider provider ignored child

### DIFF
--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -83,6 +83,28 @@ class MultiProvider extends Nested {
   /// )
   /// ```
   ///
+  /// If the some provider in `providers` has a child, this will be ignored.
+  ///
+  /// This code:
+  /// ```dart
+  /// MultiProvider(
+  ///   providers: [
+  ///     Provider<Something>(create: (_) => Something(), child: SomeWidget()),
+  ///   ],
+  ///   child: Text('Something'),
+  /// )
+  /// ```
+  /// is equivalent to:
+  ///
+  /// ```dart
+  /// MultiProvider(
+  ///   providers: [
+  ///     Provider<Something>(create: (_) => Something()),
+  ///   ],
+  ///   child: Text('Something'),
+  /// )
+  /// ```
+  ///
   /// For an explanation on the `child` parameter that `builder` receives,
   /// see the "Performance optimizations" section of [AnimatedBuilder].
   MultiProvider({

--- a/test/multi_provider_test.dart
+++ b/test/multi_provider_test.dart
@@ -71,5 +71,23 @@ void main() {
       );
       expect(Provider.of<double>(keyChild.currentContext, listen: false), 44);
     });
+
+    testWidgets('MultiProvider.providers with ignored child', (tester) async {
+      final k1 = GlobalKey();
+      final p1 = Provider.value(
+        key: k1,
+        value: 42,
+        child: const Text('Bar'),
+      );
+
+      final keyChild = GlobalKey();
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [p1],
+        child: Text('Foo', key: keyChild, textDirection: TextDirection.ltr),
+      ));
+
+      expect(find.text('Foo'), findsOneWidget);
+    });
   });
 }

--- a/test/multi_provider_test.dart
+++ b/test/multi_provider_test.dart
@@ -73,20 +73,17 @@ void main() {
     });
 
     testWidgets('MultiProvider.providers with ignored child', (tester) async {
-      final k1 = GlobalKey();
       final p1 = Provider.value(
-        key: k1,
         value: 42,
         child: const Text('Bar'),
       );
 
-      final keyChild = GlobalKey();
-
       await tester.pumpWidget(MultiProvider(
         providers: [p1],
-        child: Text('Foo', key: keyChild, textDirection: TextDirection.ltr),
+        child: const Text('Foo', textDirection: TextDirection.ltr),
       ));
 
+      expect(find.text('Bar'), findsNothing);
       expect(find.text('Foo'), findsOneWidget);
     });
   });


### PR DESCRIPTION
Adding documentation about the behavior when a provider into a MultiProvider has a non-null child.

  
If the some provider in \`providers\` has a child, this will be ignored.

This code:

\`\`\`dart  
MultiProvider(  
  providers: \[  
    Provider\<Something>(create: (\_) => Something(), child: SomeWidget()),  
  \],  
  child: Text('Something'),  
)  
\`\`\`  
  
Is equivalent to:  
\`\`\`dart  
MultiProvider(  
  providers: \[  
    Provider\<Something>(create: (\_) => Something()),  
  \],  
  child: Text('Something'),  
)  
\`\`\`