### PR TITLE
Remove hasListeners assertion from ListenableProvider

### DIFF
--- a/lib/src/listenable_provider.dart
+++ b/lib/src/listenable_provider.dart
@@ -35,35 +35,6 @@ class ListenableProvider<T extends Listenable> extends InheritedProvider<T> {
           startListening: _startListening,
           create: create,
           dispose: dispose,
-          debugCheckInvalidValueType: kReleaseMode
-              ? null
-              : (value) {
-                  if (value is ChangeNotifier) {
-                    // ignore: invalid_use_of_protected_member
-                    assert(!value.hasListeners, '''
-The default constructor of ListenableProvider/ChangeNotifierProvider
-must create a new, unused Listenable.
-
-If you want to reuse an existing Listenable, use the second constructor:
-
-- DO use ChangeNotifierProvider.value to provider an existing ChangeNotifier:
-
-MyChangeNotifier variable;
-ChangeNotifierProvider.value(
-  value: variable,
-  child: ...
-)
-
-- DON'T reuse an existing ChangeNotifier using the default constructor.
-
-MyChangeNotifier variable;
-ChangeNotifierProvider(
-  create: (_) => variable,
-  child: ...
-)
-''');
-                  }
-                },
           lazy: lazy,
           builder: builder,
           child: child,

--- a/test/listenable_provider_test.dart
+++ b/test/listenable_provider_test.dart
@@ -27,18 +27,22 @@ void main() {
           listenable);
     });
     testWidgets(
-      'asserts that the created notifier has no listener',
+      'asserts that the created notifier can have listeners',
       (tester) async {
+        final key = GlobalKey();
         final notifier = ValueNotifier(0)..addListener(() {});
 
         await tester.pumpWidget(
           ListenableProvider(
             create: (_) => notifier,
-            child: const TextOf<ValueNotifier<int>>(),
+            child: Container(key: key),
           ),
         );
 
-        expect(tester.takeException(), isAssertionError);
+        expect(
+          Provider.of<ValueNotifier<int>>(key.currentContext, listen: false),
+          notifier,
+        );
       },
     );
 


### PR DESCRIPTION
This fixes #592 and allows the following to be valid code:
```dart
ChangeNotifierProvider(
  create: (context) {
    final notifier = ValueNotifier<String>('initialValue');
    notifier.addListener(() {
      final value = notifier.value;
      // ... do stuff based on value
    });
    return notifier;
  },
  child: Text('Abc'),
};
```