### PR TITLE
`ValueListenableProvider` is no-longer deprecated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.3.2+4
+
+`ValueListenableProvider` is no-longer deprecated. Only its default constructor is deprecated (the `.value` constructor is kept)
+
 # 4.3.2+3
 
 Marked `ValueListenableProvider` as deprecated

--- a/lib/src/value_listenable_provider.dart
+++ b/lib/src/value_listenable_provider.dart
@@ -5,7 +5,6 @@ import 'listenable_provider.dart' show ListenableProvider;
 import 'provider.dart';
 
 /// Listens to a [ValueListenable] and expose its current value.
-@Deprecated('Will be removed in 5.0.0')
 class ValueListenableProvider<T>
     extends DeferredInheritedProvider<ValueListenable<T>, T> {
   /// Creates a [ValueNotifier] using [create] and automatically dispose it
@@ -20,6 +19,11 @@ class ValueListenableProvider<T>
   ///   * [ValueListenable]
   ///   * [ListenableProvider], similar to [ValueListenableProvider] but for any
   /// kind of [Listenable].
+  @Deprecated(
+    'Will be removed in 5.0.0. '
+    'Instead use a StatefulWidget and manually create/dispose the ValueNotifier, '
+    'then use ValueListenableProvider.value()',
+  )
   ValueListenableProvider({
     Key key,
     @required Create<ValueNotifier<T>> create,


### PR DESCRIPTION
Only its default constructor is deprecated (the `.value` constructor is kept)

fixes #588