### PR TITLE
Fix typo on doc

### DIFF
--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -628,7 +628,7 @@ extension WatchContext on BuildContext {
   ///
   /// This method is accessible only inside [StatelessWidget.build] and
   /// [State.build].\
-  /// If you need need to use it outside of these methods, consider using [Provider.of]
+  /// If you need to use it outside of these methods, consider using [Provider.of]
   /// instead, which doesn't have this restriction.\
   /// The only exception to this rule is Providers's `update` method.
   ///


### PR DESCRIPTION
Remove duplicated `need` word.