### PR TITLE
Create test-report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,10 @@ jobs:
 
       - name: Execute test script
         run: curl -s https://raw.githubusercontent.com/rrousselGit/ci/master/scripts/ci.sh | bash -s nnbd
+
+      - name: Upload test results
+        if: success() || failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-${{matrix.channel}}
+          path: reports/test-results.json

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -1,0 +1,19 @@
+name: Test Report
+
+on:
+  workflow_run:
+    workflows:
+    - Build
+    types:
+    - completed
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: /test-results-(.*)/
+        name: Test Report ($1)
+        path: '**/test-results.json'
+        reporter: flutter-json

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pubspec.lock
 # Conventional directory for build outputs
 build/
 coverage/
+reports/
 
 # Directory created by dartdoc
 doc/api/

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,2 @@
+file_reporters:
+  json: reports/test-results.json

--- a/test/dart_test.yaml
+++ b/test/dart_test.yaml
@@ -1,0 +1,5 @@
+# This file should normally be at the project root
+# Due to some bug it has to be here.
+# On dev channel this is already fixed
+file_reporters:
+  json: ../reports/test-results.json


### PR DESCRIPTION
Hello,

I'm developing [test-reporter](https://github.com/dorny/test-reporter) - action which displays test results directly in GitHub UI.
I tested it against few popular open source projects and provider happens to be the one for testing flutter support.
If you find it useful, this PR integrates it in your CI pipeline. If not, I would still appreciate some honest feedback :)

Here is demo how it looks:
- [successful run](https://github.com/dorny/provider/pull/1/checks?check_run_id=1945953039)
- [failing test](https://github.com/dorny/provider/pull/1/checks?check_run_id=1945897190)

Main benefit I see is it helps quickly identifying issue if some test fails only in CI. For example somebody runs tests locally only using `dev` channel but test fails on `beta`.

Due to GitHub [security restrictions](https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories) it creates report using separate workflow. This workflow must be defined on your `master` branch. So you actually won't see any report being created in this PR. It would start working after it's merged.

List of changes:
- enables json file reporter
- test results are written to reports/test-results.json
- build workflow uploads test results as artifact
- adds test-reporter workflow which runs afterwards and creates test report