### PR TITLE
Fix bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ entire tree equally:
   initState() {
     super.initState();
     Future.microtask(() =>
-      context.read<MyNotifier>(context).fetchSomething(someValue);
+      context.read<MyNotifier>().fetchSomething(someValue);
     );
   }
   ```


### PR DESCRIPTION
T read<T>() doesn't take any argument