### PR TITLE
Minimal repro and fix for mixed mode issue.

### DIFF
--- a/lib/src/inherited_provider.dart
+++ b/lib/src/inherited_provider.dart
@@ -652,12 +652,13 @@ class _CreateInheritedProviderState<T>
     extends _DelegateState<T, _CreateInheritedProvider<T>> {
   VoidCallback? _removeListener;
   bool _didInitValue = false;
+  bool _didSucceedInit = false;
   T? _value;
   _CreateInheritedProvider<T>? _previousWidget;
 
   @override
   T get value {
-    if (_didInitValue && _value is! T) {
+    if (_didInitValue && !_didSucceedInit) {
       throw StateError(
         'Tried to read a provider that threw during the creation of its value.\n'
         'The exception occurred during the creation of type $T.',
@@ -685,6 +686,7 @@ class _CreateInheritedProviderState<T>
             return true;
           }());
           _value = delegate.create!(element!);
+          _didSucceedInit = true;
         } finally {
           assert(() {
             debugIsInInheritedProviderCreate =
@@ -709,6 +711,7 @@ class _CreateInheritedProviderState<T>
             return true;
           }());
           _value = delegate.update!(element!, _value);
+          _didSucceedInit = true;
         } finally {
           assert(() {
             debugIsInInheritedProviderCreate =
@@ -724,6 +727,7 @@ class _CreateInheritedProviderState<T>
           return true;
         }());
       }
+      _didSucceedInit = true;
     }
 
     element!._isNotifyDependentsEnabled = false;

--- a/scripts/flutter_test.sh
+++ b/scripts/flutter_test.sh
@@ -3,6 +3,7 @@ cd $1
 flutter packages get
 flutter format --set-exit-if-changed lib test
 flutter analyze --no-current-package lib test/
-flutter test --no-pub --coverage
+flutter test --no-pub --coverage $(ls test/*_test.dart | grep -v _legacy_)
+flutter test --no-pub --coverage --no-sound-null-safety $(ls test/*_legacy_test.dart)
 # resets to the original state
 cd -

--- a/test/inherited_provider_legacy_test.dart
+++ b/test/inherited_provider_legacy_test.dart
@@ -1,0 +1,32 @@
+// Mixed mode: test is legacy, runtime is legacy, package:provider is null safe.
+// @dart=2.11
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+BuildContext get context => find.byType(Context).evaluate().single;
+
+class Context extends StatelessWidget {
+  const Context({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+void main() {
+  testWidgets('allows nulls in mixed mode', (tester) async {
+    int initialValueBuilder(BuildContext _) => null;
+
+    await tester.pumpWidget(
+      InheritedProvider<int>(
+        create: initialValueBuilder,
+        child: const Context(),
+      ),
+    );
+
+    expect(Provider.of<int>(context, listen: false), equals(null));
+    expect(Provider.of<int>(context, listen: false), equals(null));
+  });
+}


### PR DESCRIPTION
Fix for first issue in #652 

In the other PR review you suggested tagging a test that only runs in unsound mode with `skip` for sound mode; but I think that isn't needed here. Because of the `// @dart=2.11` comment, the test will anyway refuse to run at all in sound mode, as language version >=2.12 everywhere is required for sound mode. (The other side of your suggestion does make sense, and is for the other PR: tagging a sound mode only test so that it will not run in unsound mode).

Thanks.