### PR TITLE
Improve Chinese README

### DIFF
--- a/resources/translations/zh-CN/README.md
+++ b/resources/translations/zh-CN/README.md
@@ -1,70 +1,82 @@
 [English](../../../README.md) | [Português](./../pt_br/README.md) | [简体中文](./README.md)
 
-[![Build Status](https://travis-ci.org/rrousselGit/provider.svg?branch=master)](https://travis-ci.org/rrousselGit/provider)
-[![pub package](https://img.shields.io/pub/v/provider.svg)](https://pub.dev/packages/provider) [![codecov](https://codecov.io/gh/rrousselGit/provider/branch/master/graph/badge.svg)](https://codecov.io/gh/rrousselGit/provider) [![Gitter](https://badges.gitter.im/flutter_provider/community.svg)](https://gitter.im/flutter_provider/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+<a href="https://github.com/rrousselGit/provider/actions"><img src="https://github.com/rrousselGit/provider/workflows/Build/badge.svg" alt="Build Status"></a>
+[![codecov](https://codecov.io/gh/rrousselGit/provider/branch/master/graph/badge.svg)](https://codecov.io/gh/rrousselGit/provider) [![Gitter](https://badges.gitter.im/flutter_provider/community.svg)](https://gitter.im/flutter_provider/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-[<img src="https://raw.githubusercontent.com/rrousselGit/provider/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
+[<img src="https://raw.githubusercontent.com/rrousselGit/provider/master/resources/flutter_favorite.png" width="200" />](https://flutter.cn/docs/development/packages-and-plugins/favorites)
 
+对 [InheritedWidget][] 组件的上层封装，使其更易用，更易复用。
 
-[InheritedWidget](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) 组件的上层封装， 使其更易用， 更易复用。
-
-使用 `provider` 而非手动书写 [InheritedWidget](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html)，你会获得:
+使用 `provider` 而非手动书写 [InheritedWidget][]，有以下的优势:
 
 - 简化的资源分配与处置
 - 懒加载
-- 相较于每次创建一个新类，大大减少模板代码量
-- 对开发者工具更为友好
-- 更通用的消费 [InheritedWidget](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) 的方式(见 [Provider.of](https://pub.dev/documentation/provider/latest/provider/Provider/of.html)/[Consumer](https://pub.dev/documentation/provider/latest/provider/Consumer-class.html)/[Selector](https://pub.dev/documentation/provider/latest/provider/Selector-class.html) )
-- 提升类的可伸缩性， 整体的监听架构(`listening mechanism`)时间复杂度以指数级增长(如[ChangeNotifier](https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html)， 其复杂度为O(N²))
+- 创建新类时减少大量的模板代码
+- 支持 DevTools
+- 更通用的调用 [InheritedWidget][] 的方式（参考 [Provider.of][]/[Consumer][]/[Selector][]）
+- 提升类的可扩展性，整体的监听架构时间复杂度以指数级增长（如 [ChangeNotifier][]， 其复杂度为 O(N)）
 
-想了解更多`provider`相关， 请参考 [文档](https://pub.dev/documentation/provider/latest/provider/provider-library.html)
+想了解更多 `provider` 相关内容，请参考
+[文档](https://pub.flutter-io/documentation/provider/latest/provider/provider-library.html)
 
-也可通过以下资源学习:
+更多内容:
 
-- [the official Flutter state management documentation](https://flutter.dev/docs/development/data-and-backend/state-mgmt/simple)，展示如何结合使用`provider`与[ChangeNotifier](https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html)
-- [flutter architecture sample](https://github.com/brianegan/flutter_architecture_samples/tree/master/change_notifier_provider)，使用`provider`与[ChangeNotifier](https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html)的应用具体实现
-- [flutter_bloc](https://github.com/felangel/bloc) and [Mobx](https://github.com/mobxjs/mobx.dart)，在BLoC与Mobx架构中使用`provider`
+- [Flutter 官方的状态管理文档](https://flutter.cn/docs/development/data-and-backend/state-mgmt/simple)，
+  展示如何将 `provider` 与 [ChangeNotifier][] 结合使用。
+- [Flutter 架构示例](https://github.com/brianegan/flutter_architecture_samples/tree/master/change_notifier_provider)，
+  使用 `provider` 与 [ChangeNotifier][] 实现的具体应用。
+- [flutter_bloc](https://github.com/felangel/bloc) 和
+  [Mobx](https://github.com/mobxjs/mobx.dart)，在 BLoC 与 Mobx 架构中使用 `provider`。
 
-## 从 v3.x.0 迁移至 v4.0.0
+## 自 4.x.x 版本升级到 5.0.0-nullsafety
 
-- providers的 builder 与 initialBuilder 参数被移除
+- `FutureProvider` 和 `StreamProvider` 现在要求声明 `initialData`。
 
-  - `initialBuilder`现在应当被 `create` 代替
-  - 代理类providers(如 `ProxyProvider` )的 `builder` 属性应当被 `update` 代替
-  - 普通providers的 `builder` 属性应当被 `create` 代替
-
-- 新的 create/update 回调函数是懒加载的， 也就是说他们在对应的值第一次被读取时才被调用， 而非provider首次被创建时.
-
-  如果你不需要这个特性， 你可以通过将provider的lazy属性置为false， 来禁用懒加载
+  待迁移的旧代码：
 
   ```dart
-  FutureProvider(
-    create: (_) async => doSomeHttpRequest()，
-    lazy: false，
-    child: ...
+  FutureProvider<int>(
+    create: (context) => Future.value(42),
+    child: MyApp(),
   )
+
+  Widget build(BuildContext context) {
+    final value = context.watch<int>();
+    return Text('$value');
+  }
   ```
 
-- `ProviderNotFoundError` 更名为 `ProviderNotFoundException`.
-
-- `SingleChildCloneableWidget` 接口被移除， 并被全新类型的组件 `SingleChildWidget` 所替代
-
-  参考这个 [issue](https://github.com/rrousselGit/provider/issues/237) 来获取迁移细节.
-
-- [Selector](https://pub.dev/documentation/provider/latest/provider/Selector-class.html) 现在会将先后的**集合类型的值**进行深层对比
-
-  如果你不需要这个特性， 你可以通过 `shouldRebuild` 参数来使其还原至旧有表现.
+  迁移后：
 
   ```dart
-  Selector<Selected， Consumed>(
-    shouldRebuild: (previous， next) => previous == next，
-    builder: ...，
+  FutureProvider<int?>(
+    initialValue: null,
+    create: (context) => Future.value(42),
+    child: MyApp(),
   )
+
+  Widget build(BuildContext context) {
+    // be sure to specify the ? in watch<int?>
+    final value = context.watch<int?>();
+    return Text('$value');
+  }
   ```
 
-- `DelegateWidget`及其家族widget被移除， 现在想要自定义provider， 直接继承 [InheritedProvider](https://pub.dev/documentation/provider/latest/provider/InheritedProvider-class.html) 或当前存在的provider.
+- `ValueListenableProvider` 已被移除
 
+  你只需要将 `ValueListenableBuilder` 与 `Provider` 结合使用即可：
 
+  ```dart
+  ValueListenableBuilder<int>(
+    valueListenable: myValueListenable,
+    builder: (context, value, _) {
+      return Provider<int>.value(
+        value: value,
+        child: MyApp(),
+      );
+    }
+  )
+  ```
 
 ## 使用
 
@@ -72,118 +84,125 @@
 
 #### 暴露一个新的对象实例
 
-Providers不仅允许暴露出一个值，也可以创建/监听/销毁它。
+Provider 不仅可以暴露出一个值，同时也可以创建、监听和销毁它。
 
-要暴露一个新创建的对象， 使用一个provider的默认构造函数. 如果你想**创建**一个对象， **不要**使用 `.value` 构造函数， 否则可能会有你预期外的副作用。
+要暴露一个新创建的对象，你可以使用这个 provider 的默认构造。
+而如果你想在开始监听时再 **创建** 一个对象，
+**不要**使用 `.value` 构造函数，否则可能会有你预期外的副作用。
 
-查看该 [StackOverflow Answer](https://stackoverflow.com/questions/52249578/how-to-deal-with-unwanted-widget-build)，来了解更多为什么不要使用`.value`构造函数创建值。
+你可以阅读在 [StackOverflow 上的回答](https://stackoverflow.com/questions/52249578/how-to-deal-with-unwanted-widget-build)
+以了解为什么不推荐使用 `.value` 构造函数创建值。
 
-- **在create内创建新对象**
+- **要** 在 `create` 内创建新对象**。
 
   ```dart
   Provider(
-    create: (_) => MyModel()，
+    create: (_) => MyModel(),
     child: ...
   )
   ```
 
-- **不要使用`Provider.value`创建对象**
+- **不要** 使用 `Provider.value` 创建新对象**。
 
   ```dart
   ChangeNotifierProvider.value(
-    value: MyModel()，
+    value: MyModel(),
     child: ...
   )
   ```
 
-- 不要以**可能随时间改变的变量**创建对象
+- **不要** 以可能随时间改变的变量创建对象。
 
-  在这种情况下，如果变量发生变化，你的对象将永远不会被更新
+  在以下变量发生变化的场景里，你的对象将不会跟随值的变化而更新。
   
   ```dart
   int count;
   
   Provider(
-    create: (_) => MyModel(count)，
+    create: (_) => MyModel(count),
     child: ...
   )
   ```
 
-	如果你想将随时间改变的变量传入给对象，请使用`ProxyProvider`:
-	
-	 ```dart
-	int count;
-	
-	ProxyProvider0(
-	  update: (_， __) => MyModel(count)，
-	  child: ...
-	)
-	 ```
-	
-	
+  如果你想将可能被外界修改的变量传入给对象，请使用 `ProxyProvider`：
 
-**注意:**
+  ```dart
+  int count;
 
-在使用一个provider的`create`/`update`回调时，请注意回调函数默认是**懒调用**的。
+  ProxyProvider0(
+    update: (_， __) => MyModel(count),
+    child: ...
+  )
+  ```
 
-也就是说， 除非这个值被读取了至少一次， 否则`create`/`update`函数不会被调用。
+**请注意：**
 
-如果你想预先计算一些逻辑， 可以通过使用`lazy`参数来禁用这一行为。
+在使用一个 provider 的 `create` 和 `update` 回调时，回调函数默认是延迟调用的。
+
+也就是说，变量被读取时，`create` 和 `update` 函数才会被调用。
+
+如果你想预先计算一些对象内的逻辑，可以使用 `lazy` 参数来禁用这一行为。
 
 ```dart
 MyProvider(
-  create: (_) => Something()，
-  lazy: false，
+  create: (_) => Something(),
+  lazy: false,
 )
 ```
 
-#### 复用一个已存在的对象实例:
+#### 复用一个已存在的对象实例：
 
-如果你已经拥有一个对象实例并且想暴露出它，你应当使用一个provider的`.value`构造函数。
+如果你要将一个已经存在的对象实例暴露出来，
+你应当使用 provider 的 `.value` 构造函数。
 
-如果你没有这么做，那么在你调用对象的 `dispose` 方法时， 这个对象可能仍然在被使用。
+如果你没有这么做，那么在你调用对象的 `dispose` 方法时，
+这个对象可能仍然在被使用，导致无法释放。
 
-- **使用`ChangeNotifierProvider.value`来提供一个当前已存在的 [ChangeNotifier](https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html)**
+- **要** 使用 `ChangeNotifierProvider.value` 来提供一个当前已存在的 [ChangeNotifier][]
 
   ```dart
   MyChangeNotifier variable;
   
   ChangeNotifierProvider.value(
-    value: variable，
+    value: variable,
     child: ...
   )
   ```
 
-- 不要使用默认的构造函数来尝试复用一个已存在的 [ChangeNotifier](https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html)
+- **不要** 使用默认的构造函数来尝试复用一个已存在的 [ChangeNotifier][]
 
   ```dart
   MyChangeNotifier variable;
   
   ChangeNotifierProvider(
-    create: (_) => variable，
+    create: (_) => variable,
     child: ...
   )
   ```
 
+### 读取值
 
+最简单的读取值的方式就是使用 `BuildContext` 上的扩展属性（由 `provider` 注入）。
 
-### 读取一个值
+- `context.watch<T>()`，widget 能够监听到 `T` 类型的 provider 发生的改变。
+- `context.read<T>()`，直接返回 `T`，不会监听改变。
+- `context.select<T，R>(R cb(T value))`，允许 widget 只监听 `T` 上的一部分内容的改变。
 
-读取一个值最简单的方式就是使用`BuildContext`上的扩展属性(由`provider`注入)。
+你也可以使用 `Provider.of<T>(context)` 这一静态方法，它的表现类似 `watch`，
+而在你为传入 `listen: false` 参数时（例如 `Provider.of<T>(context，listen: false)`），
+它的表现与 `read` 类似。
 
-- `context.watch<T>()`， 一方法使得widget能够监听泛型`T`上发生的改变。
-- `context.read<T>()`，直接返回`T`，不会监听改变。
-- `context.select<T， R>(R cb(T value))`，允许widget只监听`T`上的一部分(`R`)。
+值得注意的是，`context.read<T>()` 方法不会在值变化时让 widget 重新构建，
+并且不能在 `StatelessWidget.build` 和 `State.build` 内调用. 
+换句话说，它可以在除了这两个方法以外的任意位置调用。
 
-或者使用 `Provider.of<T>(context) `这一静态方法，它的表现类似 `watch` ，而在你为 `listen` 参数传入 `false` 时(如 `Provider.of<T>(context，listen: false)` )，它的表现类似于 `read`。
+上面列举的这些方法会从传入的 `BuildContext` 关联的 widget 开始，向上查找 widget 树，
+并返回查找到的层级最近的 `T` 类型的 provider（未找到时将抛出错误）。
 
-值得注意的是，`context.read<T>()` 方法不会在值变化时使得widget重新构建， 并且不能在 `StatelessWidget.build`/`State.build` 内调用. 换句话说， 它可以在除了这两个方法以外的任意之处调用。
+值得一提的是，该操作的复杂度是 O(1)，它实际上并不会遍历整个组件树。
 
-上面列举的这些方法会与传入的 `BuildContext` 关联的widget开始查找widget树，并返回查找到的最近的类型T的变量(如果没有找到， 将抛出错误)。
-
-值得注意是这一操作的复杂度是 O(1)，它实际上并不涉及遍历整个组件树。
-
-结合上面第一个[向外暴露一个值](https://github.com/rrousselGit/provider/blob/master/README.md#exposing-a-value)的例子，这个widget会读取暴露出的`String`并渲染`Hello World`。
+结合上面第一个 [暴露一个值](#暴露一个值) 的例子，
+widget 会读取暴露出的 `String` 并渲染 `Hello World`。
 
 ```dart
 class Home extends StatelessWidget {
@@ -191,76 +210,93 @@ class Home extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       // Don't forget to pass the type of the object you want to obtain to `watch`!
-      context.watch<String>()，
+      context.watch<String>(),
     );
   }
 }
 ```
 
-或者不使用这些方法，我们也可以使用 [Consumer](https://pub.dev/documentation/provider/latest/provider/Consumer-class.html) 与 [Selector](https://pub.dev/documentation/provider/latest/provider/Selector-class.html)。
+如果不想使用这些方法，你也也可以使用 [Consumer][] 和 [Selector][]。
 
-这些往往在**性能优化**以及当**很难获取到provider的构建上下文后代**(difficult to obtain a `BuildContext` descendant of the provider) 时是很有用的。
+它们往往在一些需要 **性能优化** 的场景，
+以及当 widget 很难获取到 provider 所在层级以下的 `BuildContext` 时非常有用。
 
+查阅 [FAQ](#我的-widget-重新-build-太频繁了，我应该怎么做？)
+或关于 [Consumer][] 和 [Selector][] 的文档了解更多。
 
+### 依赖可能不存在的 Provider
 
-参见 [FAQ](https://github.com/rrousselGit/provider#my-widget-rebuilds-too-often-what-can-i-do) 或关于[Consumer](https://pub.dev/documentation/provider/latest/provider/Consumer-class.html) 和 [Selector](https://pub.dev/documentation/provider/latest/provider/Selector-class.html) 的文档部分了解更多.
+某些情况下，我们可能需要支持 provider 不存在的查询。
+例如一个可能在 provider 以外使用的封装复用的 widget。
 
+此时你可以将 `context.watch` 和 `context.read` 对应的 `T` 声明为可空的类型。
 
+假设原有的代码为：
+
+```dart
+context.watch<Model>()
+```
+
+会在找不到 provider 时抛出 `ProviderNotFoundException`，而按以下方法修改后：
+
+```dart
+context.watch<Model?>()
+```
+
+在查询时会尝试找到匹配 provider，未找到时返回 `null` 而不会抛出异常。
 
 ### MultiProvider
 
-当在大型应用中注入较多状态时， `Provider` 很容易变得高度耦合:
+在大型应用中注入较多内容时，`Provider` 的时候很容易产生多层嵌套：
 
 ```dart
 Provider<Something>(
-  create: (_) => Something()，
+  create: (_) => Something(),
   child: Provider<SomethingElse>(
-    create: (_) => SomethingElse()，
+    create: (_) => SomethingElse(),
     child: Provider<AnotherThing>(
-      create: (_) => AnotherThing()，
-      child: someWidget，
-    )，
-  )，
-)，
+      create: (_) => AnotherThing(),
+      child: someWidget,
+    ),
+  ),
+),
 ```
 
-使用`MultiProvider`:
+这时你可以使用 `MultiProvider`：
 
 ```dart
 MultiProvider(
   providers: [
-    Provider<Something>(create: (_) => Something())，
-    Provider<SomethingElse>(create: (_) => SomethingElse())，
-    Provider<AnotherThing>(create: (_) => AnotherThing())，
-  ]，
-  child: someWidget，
+    Provider<Something>(create: (_) => Something()),
+    Provider<SomethingElse>(create: (_) => SomethingElse()),
+    Provider<AnotherThing>(create: (_) => AnotherThing()),
+  ],
+  child: someWidget,
 )
 ```
 
-以上两个例子的实际表现是一致的， `MultiProvider`唯一改变的就是代码书写方式.
-
-
+以上两个例子的实际表现是一致的，`MultiProvider` 仅仅是改变了代码的书写方式。
 
 ### ProxyProvider
 
-从3.0.0开始， 我们提供了一种新的provider: `ProxyProvider`.
+从 3.0.0 开始，我们提供了一种新的 provider：`ProxyProvider`。
 
-`ProxyProvider`能够将多个来自于其他的providers的值聚合为一个新对象，并且将结果传递给`Provider`。
+`ProxyProvider` 能够将多个 provider 的值聚合为一个新对象，将结果传递给 `Provider`。
 
-这个新对象会在其依赖的任一providers更新后被更新
+这个新对象会在其依赖的任意一个 provider 更新后同步更新。
 
-下面的例子使用`ProxyProvider`，基于来自于另一个provider的counter值进行转化。
+下面的例子使用了 `ProxyProvider`，基于另一个 provider 的 counter 值进行转化。
 
 ```dart
 Widget build(BuildContext context) {
   return MultiProvider(
     providers: [
-      ChangeNotifierProvider(create: (_) => Counter())，
-      ProxyProvider<Counter， Translations>(
-        update: (_， counter， __) => Translations(counter.value)，
-      )，
-    ]，
-    child: Foo()，
+      ChangeNotifierProvider(create: (_) => Counter()),
+      ProxyProvider<Counter, Translations>(
+        update: (_, counter, __) => Translations(counter.value),
+      ),
+    ],
+    child: Foo(),
   );
 }
 
@@ -273,49 +309,48 @@ class Translations {
 }
 ```
 
-这个例子还有多种变化:
+它还有其他不同的形式：
 
-- `ProxyProvider` vs `ProxyProvider2` vs `ProxyProvider3`， ...
+- `ProxyProvider`、`ProxyProvider2`、`ProxyProvider3` ...
 
-  类名后的数字是 `ProxyProvider` 依赖的其他providers的数量
+  类名后的数字是 `ProxyProvider` 依赖的 provider 的数量。
 
-  
+- `ProxyProvider`、`ChangeNotifierProxyProvider`、`ListenableProxyProvider` ...
 
-- `ProxyProvider` vs `ChangeNotifierProxyProvider` vs `ListenableProxyProvider`， ...
+  它们工作的方式是相似的，但 `ChangeNotifierProxyProvider`
+  会将它的值传递给 `ChangeNotifierProvider` 而非 `Provider`。
 
-  它们工作的方式是相似的， 但 `ChangeNotifierProxyProvider` 会将它的值传递给`ChangeNotifierProvider` 而非 `Provider`。
-
-### FAQ
+### 常见问题
 
 #### 我是否能查看(inspect)我的对象的内容?
 
-Flutter提供的[开发者工具](https://github.com/flutter/devtools)能够展示特定时刻下的widget树。
+Flutter 提供的 [DevTools](https://github.com/flutter/devtools) 能够展示特定时刻下的 widget 树。
 
-既然providers同样是widget，他们同样能通过开发者工具进行查看。
+既然 provider 也同样是 widget，那么它们同样能通过 DevTools 进行查看。
 
-![img](https://raw.githubusercontent.com/rrousselGit/provider/master/resources/devtools_providers.jpg)
+<img src="https://raw.githubusercontent.com/rrousselGit/provider/master/resources/devtools_providers.jpg" width="200" />
 
-点击一个provider， 即可查看它暴露出的值:
+点击一个 provider，即可查看它暴露出的值:
 
-![img](https://raw.githubusercontent.com/rrousselGit/provider/master/resources/expanded_devtools.jpg)
+<img src="https://raw.githubusercontent.com/rrousselGit/provider/master/resources/expanded_devtools.jpg" width="200" />
 
-以上的开发者工具截图来自于 `/example` 文件夹下的示例
+（以上的开发者工具截图来自于 `/example` 文件夹下的示例）
 
+#### DevTools 只显示了「Instance of MyClass」，我应该怎么做？
 
-
-#### 开发者工具只显示"Instance of MyClass"， 我能做什么?
-
-默认情况下， 开发者工具基于`toString`，也就使得默认结果是 "Instance of MyClass"。
+默认情况下，DevTools 基于 `toString`，也就使得默认结果是「Instance of MyClass」。
 
 如果要得到更多信息，你有两种方式:
 
-- 使用Flutter提供的 [Diagnosticable](https://api.flutter.dev/flutter/foundation/Diagnosticable-class.html) API
+- 使用 Flutter 提供的 [Diagnosticable](https://api.flutter-io.cn/flutter/foundation/Diagnosticable-class.html) API
 
-  在大多数情况下， 只需要在你的对象上使用 [DiagnosticableTreeMixin](https://api.flutter.dev/flutter/foundation/DiagnosticableTreeMixin-mixin.html) 即可，以下是一个自定义 [debugFillProperties](https://api.flutter.dev/flutter/foundation/DiagnosticableTreeMixin/debugFillProperties.html) 实现的例子:
+  在大多数情况下，你只需要在对象上使用 [DiagnosticableTreeMixin][diagnosticabletreemixin] 即可，
+  以下是一个自定义 [debugFillProperties](https://api.flutter-io.cn/flutter/foundation/DiagnosticableTreeMixin/debugFillProperties.html)
+  实现的例子:
 
   ```dart
   class MyClass with DiagnosticableTreeMixin {
-    MyClass({this.a， this.b});
+    MyClass({this.a, this.b});
   
     final int a;
     final String b;
@@ -325,39 +360,41 @@ Flutter提供的[开发者工具](https://github.com/flutter/devtools)能够展�
       super.debugFillProperties(properties);
       // list all the properties of your class here.
       // See the documentation of debugFillProperties for more information.
-      properties.add(IntProperty('a'， a));
-      properties.add(StringProperty('b'， b));
+      properties.add(IntProperty('a', a));
+      properties.add(StringProperty('b', b));
     }
   }
   ```
 
-- 重写`toString`方法
+- 重写 `toString` 方法
 
-  如果你无法使用 [DiagnosticableTreeMixin](https://api.flutter.dev/flutter/foundation/DiagnosticableTreeMixin-mixin.html) (比如你的类在一个不依赖于Flutter的包中)， 那么你可以通过简单重写`toString`方法来达成效果。
-  
-  这比使用 [DiagnosticableTreeMixin](https://api.flutter.dev/flutter/foundation/DiagnosticableTreeMixin-mixin.html) 要更简单，但能力也有着不足: 你无法 展开/折叠 来查看你的对象内部细节。
-  
+  如果你无法使用 [DiagnosticableTreeMixin][diagnosticabletreemixin]（比如你的类在一个不依赖于 Flutter 的 package 中），
+  那么你可以通过重写 `toString` 方法来达成效果。
+ 
+  这比使用 [DiagnosticableTreeMixin][diagnosticabletreemixin] 要更简单，但能力也有着不足：
+  你无法查看你的对象内部细节。
+
   ```dart
   class MyClass with DiagnosticableTreeMixin {
-    MyClass({this.a， this.b});
+    MyClass({this.a, this.b});
   
     final int a;
     final String b;
   
     @override
     String toString() {
-      return '$runtimeType(a: $a， b: $b)';
+      return '$runtimeType(a: $a, b: $b)';
     }
   }
   ```
 
-#### 在获得`initState`内部的Providers时发生了异常， 该做什么?
+#### 在 `initState` 方法里调用 provider 的获取方法时发生了异常，我应该怎么做?
 
-这个异常的出现是因为你在尝试监听一个来自于**永远不会再次被调用的生命周期**的provider。
+异常的出现是因为你尝试在一个 **永远不会再次被调用的生命周期** 监听 provider。
 
-这意味着你要么使用另外一个生命周期(`build`)，要么显式指定你并不在意后续更新。
+这意味着你要么使用另外一个生命周期 (`build`)，要么显式声明你并不在意后续更新。
 
-也就是说，不应该这么做:
+也就是说，原本你的代码是：
 
 ```dart
 initState() {
@@ -366,7 +403,7 @@ initState() {
 }
 ```
 
-你可以这么做:
+现在你应该这么写：
 
 ```dart
 Value value;
@@ -380,9 +417,9 @@ Widget build(BuildContext context) {
 }
 ```
 
-这会且只会在`value`变化时打印它。
+此时 print 只会在 `value` 变化时执行。
 
-或者你也可以这么做:
+或者你也可以这么做：
 
 ```dart
 initState() {
@@ -391,11 +428,11 @@ initState() {
 }
 ```
 
-这样只会打印一次value，并且会忽视后续的更新
+这样只会打印一次 `value`，并且 **忽略后续的更新**。
 
-#### 如何控制我的对象上的热更新?
+#### 如何在热更新 (hot-reload) 时处理我的对象？
 
-你可以使你提供的对象实现 `ReassembleHandler` 类:
+你可以将你的 provider 对象实现 `ReassembleHandler` 类：
 
 ```dart
 class Example extends ChangeNotifier implements ReassembleHandler {
@@ -406,17 +443,17 @@ class Example extends ChangeNotifier implements ReassembleHandler {
 }
 ```
 
-通常会和 `provider` 一同使用:
+它们通常会和 `provider` 一同使用:
 
 ```dart
-ChangeNotifierProvider(create: (_) => Example())，
+ChangeNotifierProvider(create: (_) => Example()),
 ```
 
-#### 使用[ChangeNotifier](https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html)时， 在更新后出现了异常， 发生了什么?
+#### 使用 [ChangeNotifier] 时，在更新后出现了异常，发生了什么？
 
-这通常是因为你**在widget树正在构建时**，从[ChangeNotifier](https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html)的某个后代更改了ChangeNotifier。
+通常这是因为 **在widget树正在构建时**，[ChangeNotifier][] 的某个后代更改了 ChangeNotifier。
 
-最典型的情况是在一个future被保存在notifier内部时发起http请求。
+最典型的情况是一个发起 Http 请求的 `Future` 被保存在 notifier 内部：
 
 ```dart
 initState() {
@@ -425,13 +462,15 @@ initState() {
 }
 ```
 
-这是不被允许的，因为更改会立即生效.
+这是不被允许的，因为更改会立即生效。
 
-也就是说，一些widget可能在**变更发生前**构建，而有些则可能在**变更后**. 这可能造成UI不一致， 因此是被禁止的。
+也就是说，一些 widget 可能在 **变更发生前**（获取到旧的值）构建，
+而另一些则可能在 **变更后**（获取到新的值）构建。
+这可能造成 UI 不一致，因此是被禁止的。
 
-所以，你应该在一个**整个widget树所受影响相同的位置**执行变更:
+所以，你应该在整个 widget 树都能受影响的位置执行变更：
 
-- 直接在你的model的 provider/constructor 的 `create` 方法内调用:
+- 在你的 model 的构造方法内直接调用：
 
   ```dart
   class MyNotifier with ChangeNotifier {
@@ -445,7 +484,7 @@ initState() {
 
   在不需要传入形参的情况下，这是相当有用的。
 
-- 在框架的末尾异步的执行(`Future.microtask`):
+- 在构建帧的末尾异步执行 (`Future.microtask`)：
 
   ```dart
   initState() {
@@ -455,20 +494,20 @@ initState() {
     );
   }
   ```
-  
-  这可能不是理想的使用方式，但它允许你向变更传递参数。
+  这可能不是理想的使用方式，但你可以利用这样的方法向变更传递参数。
 
-#### 我必须为复杂状态使用 [ChangeNotifier](https://api.flutter.dev/flutter/foundation/ChangeNotifier-class.html) 吗?
+#### 处理复杂状态时必须使用 [ChangeNotifier][] 吗？
 
-不。
+当然不是。
 
-你可以使用任意对象来表示你的状态，举例来说，一个可选的架构方案是使用`Provider.value`配合`StatefulWidget`
+你可以使用任意对象来表示你的状态。举例来说，
+一个可选的架构方案是使用 `Provider.value` 配合 `StatefulWidget`。
 
-这是一个使用这种架构的计数器示例:
+下面是使用这种架构的计数器示例：
 
 ```dart
 class Example extends StatefulWidget {
-  const Example({Key key， this.child}) : super(key: key);
+  const Example({Key key, this.child}) : super(key: key);
 
   final Widget child;
 
@@ -488,45 +527,45 @@ class ExampleState extends State<Example> {
   @override
   Widget build(BuildContext context) {
     return Provider.value(
-      value: _count，
+      value: _count,
       child: Provider.value(
-        value: this，
-        child: widget.child，
-      )，
+        value: this,
+        child: widget.child,
+      ),
     );
   }
 }
 ```
 
-我们可以通过这样来读取状态:
+我们可以通过以下的方式来读取状态：
 
 ```dart
 return Text(context.watch<int>().toString());
 ```
 
-并且这样来修改状态:
+接着按以下的方式来修改状态：
 
 ```dart
 return FloatingActionButton(
-  onPressed: () => context.read<ExampleState>().increment()，
-  child: Icon(Icons.plus_one)，
+onPressed: () => context.read<ExampleState>().increment(),
+child: Icon(Icons.plus_one),
 );
 ```
 
-或者你还可以自定义provider.
+又或者自定义 provider 进行处理。
 
-#### 我可以创建自己的Provider吗?
+#### 我可以创建自己的 Provider吗？
 
 可以，`provider`暴露出了所有构建功能完备的provider所需的组件，它包含:
 
-- `SingleChildStatelessWidget`， 使任意widget能够与 `MultiProvider` 协作， 这个接口被暴露为包 `package:provider/**single_child_widget` 的一部分**
-- [InheritedProvider](https://pub.dev/documentation/provider/latest/provider/InheritedProvider-class.html)，在使用 `context.watch` 时可获取的通用`InheritedWidget`。
+- `SingleChildStatelessWidget`，任意的 widget 都能够与 `MultiProvider` 协作。
+  这个接口暴露为 `package:provider/single_child_widget` 的一部分。
+- [InheritedProvider][]，在使用 `context.watch` 时可获取的通用 `InheritedWidget`。
 
-这里有个使用 `ValueNotifier` 作为状态的自定义provider例子:
-
+此处为一个使用 `ValueNotifier` 作为状态自定义 provider 的例子：
 https://gist.github.com/rrousselGit/4910f3125e41600df3c2577e26967c91
 
-#### 我的widget重构建太频繁了， 我能做什么?
+#### 我的 widget 重新 build 太频繁了，我应该怎么做？
 
 你可以使用 `context.select` 而非 `context.watch` 来指定只监听对象的部分属性:
 
@@ -539,9 +578,9 @@ Widget build(BuildContext context) {
 }
 ```
 
-这可能导致widget在 `name` 以外的属性发生变化时重构建。
+这可能导致 widget 在 `name` 以外的属性发生变化时也重新进行了构建。
 
-你可以使用 `context.select`来 只监听`name`属性
+你可以使用 `context.select` 来单独监听 `name` 属性：
 
 ```dart
 Widget build(BuildContext context) {
@@ -550,54 +589,57 @@ Widget build(BuildContext context) {
 }
 ```
 
-这样，这widget间就不会在`name`以外的属性变化时进行不必要的重构建了。
+如此一来，widget 就不会在 `name` 以外的属性变化时，进行不必要的重构建了。
 
-同样，你也可以使用[Consumer](https://pub.dev/documentation/provider/latest/provider/Consumer-class.html)/[Selector](https://pub.dev/documentation/provider/latest/provider/Selector-class.html)，可选的`child`参数使得widget树中只有所指定的一部分会重构建。
+同样，你也可以使用 [Consumer][]/[Selector][]，
+可选的 `child` 参数使得 widget 树中只有指定的一部分会重构建。
 
 ```dart
 Foo(
   child: Consumer<A>(
-    builder: (_， a， child) {
-      return Bar(a: a， child: child);
-    }，
-    child: Baz()，
-  )，
+    builder: (_, a, child) {
+      return Bar(a: a, child: child);
+    },
+    child: Baz(),
+  ),
 )
 ```
 
-在这个示例中， 只有`Bar`会在`A`更新时重构建，`Foo`与`Baz`不会进行不必要的重构建。
+在这个示例中，只有 `Bar` 会在 `A` 更新时重构建，
+`Foo` 与`Baz` 会避免进行不必要的重复构建。
 
-#### 我能使用相同类型来获得两个不同的provider吗?
+#### 我可以使用相同类型来查找两个不同的 provider 吗？
 
-不。 当你有两个持有相同类型的不同provider时，一个widget只会获取其中之一: **最近的一个**。
+不。当你有两个相同类型的不同 provider 时，一个 widget 只会获取 **最近的一个**。
 
-你必须显式为两个provider提供不同类型，而不是:
+你必须显式声明两个 provider 为不同类型，而不是：
 
 ```dart
 Provider<String>(
-  create: (_) => 'England'，
+  create: (_) => 'England',
   child: Provider<String>(
-    create: (_) => 'London'，
-    child: ...，
-  )，
-)，
+    create: (_) => 'London',
+    child: ...,
+  ),
+),
 ```
 
 推荐的写法:
 
 ```dart
 Provider<Country>(
-  create: (_) => Country('England')，
+  create: (_) => Country('England'),
   child: Provider<City>(
-    create: (_) => City('London')，
-    child: ...，
-  )，
-)，
+    create: (_) => City('London'),
+    child: ...,
+  ),
+),
 ```
 
-#### 我能消费一个接口并且提供一个实现吗?
+#### 我可以消费一个接口并且提供一个实现吗？
 
-能，类型提示(`type hint`)必须被提供给编译器，来指定将要被消费的接口，同时需要在`craete`中提供具体实现:
+可以，编译器需要你提供类型提示 (`type hint`)，来指定将要被消费的接口，
+同时你需要在 `craete` 中提供具体实现:
 
 ```dart
 abstract class ProviderInterface with ChangeNotifier {
@@ -617,22 +659,30 @@ class Foo extends StatelessWidget {
 }
 
 ChangeNotifierProvider<ProviderInterface>(
-  create: (_) => ProviderImplementation()，
-  child: Foo()，
-)，
+  create: (_) => ProviderImplementation(),
+  child: Foo(),
+),
 ```
 
-#### 现有的providers
+#### 现有的 providers
 
-`provider`中提供了几种不同类型的"provider"，供不同类型的对象使用。
+`provider` 中提供了几种不同类型的「provider」，供不同类型的对象使用。
 
-完整的可用列表参见 [provider-library]([here](https://pub.dev/documentation/provider/latest/provider/provider-library.html))
+完整的可用列表参见 [此处](https://pub.flutter-io.cn/documentation/provider/latest/provider/provider-library.html)。
 
-| name                                                                                                                          | description                                                                                               |
-| ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| [Provider](https://pub.dartlang.org/documentation/provider/latest/provider/Provider-class.html)                               | 最基础的provider组成，接收一个值并暴露它， 无论值是什么。                                                 |
-| [ListenableProvider](https://pub.dartlang.org/documentation/provider/latest/provider/ListenableProvider-class.html)           | 供可监听对象使用的特殊provider，ListenableProvider会监听对象，并在监听器被调用时更新依赖此对象的widgets。 |
-| [ChangeNotifierProvider](https://pub.dartlang.org/documentation/provider/latest/provider/ChangeNotifierProvider-class.html)   | 为ChangeNotifier提供的ListenableProvider规范，会在需要时自动调用`ChangeNotifier.dispose`。                |
-| [ValueListenableProvider](https://pub.dartlang.org/documentation/provider/latest/provider/ValueListenableProvider-class.html) | 监听ValueListenable，并且只暴露出`ValueListenable.value`。                                                |
-| [StreamProvider](https://pub.dartlang.org/documentation/provider/latest/provider/StreamProvider-class.html)                   | 监听流，并暴露出当前的最新值。                                                                            |
-| [FutureProvider](https://pub.dartlang.org/documentation/provider/latest/provider/FutureProvider-class.html)                   | 接收一个`Future`，并在其进入complete状态时更新依赖它的组件。                                              |
+| 名称                                                                                                                           | 描述                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| [Provider](https://pub.flutter-io.cn/documentation/provider/latest/provider/Provider-class.html)                               | 最基础的 provider 组成，接收一个任意值并暴露它。                                                           |
+| [ListenableProvider](https://pub.flutter-io.cn/documentation/provider/latest/provider/ListenableProvider-class.html)           | 供可监听对象使用的特殊 provider。ListenableProvider 会监听对象，并在监听器被调用时更新依赖此对象的 widgets。     |
+| [ChangeNotifierProvider](https://pub.flutter-io.cn/documentation/provider/latest/provider/ChangeNotifierProvider-class.html)   | 为 ChangeNotifier 提供的 ListenableProvider 规范，会在需要时自动调用 `ChangeNotifier.dispose`。            |
+| [ValueListenableProvider](https://pub.flutter-io.cn/documentation/provider/latest/provider/ValueListenableProvider-class.html) | 监听 ValueListenable，并且只暴露出 `ValueListenable.value`。                                            |
+| [StreamProvider](https://pub.flutter-io.cn/documentation/provider/latest/provider/StreamProvider-class.html)                   | 监听流，并暴露出当前的最新值。                                                                            |
+| [FutureProvider](https://pub.flutter-io.cn/documentation/provider/latest/provider/FutureProvider-class.html)                   | 接收一个 `Future`，并在其进入 complete 状态时更新依赖它的组件。                                             |
+
+[provider.of]: https://pub.flutter-io.cn/documentation/provider/latest/provider/Provider/of.html
+[selector]: https://pub.flutter-io.cn/documentation/provider/latest/provider/Selector-class.html
+[consumer]: https://pub.flutter-io.cn/documentation/provider/latest/provider/Consumer-class.html
+[changenotifier]: https://api.flutter-io.cn/flutter/foundation/ChangeNotifier-class.html
+[inheritedwidget]: https://api.flutter-io.cn/flutter/widgets/InheritedWidget-class.html
+[inheritedprovider]: https://pub.flutter-io.cn/documentation/provider/latest/provider/InheritedProvider-class.html
+[diagnosticabletreemixin]: https://api.flutter-io.cn/flutter/foundation/DiagnosticableTreeMixin-mixin.html


### PR DESCRIPTION
This PR improves README in Chinese language. It mainly changes below things:
- Sync badges, code snippets, and other contents.
- Improve explanations to sentences in order to explain the original content clearer.
- Use correct punctuation according to [our translation spec](https://github.com/cfug/flutter.cn/wiki/%E6%96%87%E6%A1%A3%E7%BF%BB%E8%AF%91%E6%A0%BC%E5%BC%8F-(Translation-Spec)). 
- Replace mirrored links with our mirror site (flutter.cn, flutter-io.cn, maintained by CFUG&mdash;Chinese Flutter User Group).

cc @linbudu599 who wrote the first version of the README.
@rrousselGit Thanks for this package and you can review this once you have spare time.