### PR TITLE
Explicitly mention rebuild in context.select() doc

### DIFF
--- a/lib/src/inherited_provider.dart
+++ b/lib/src/inherited_provider.dart
@@ -185,8 +185,8 @@ bool _debugIsSelecting = false;
 
 /// Adds a `select` method on [BuildContext].
 extension SelectContext on BuildContext {
-  /// Watch a value of type [T] exposed from a provider, and listen only partially
-  /// to changes.
+  /// Watch a value of type [T] exposed from a provider, and mark this widget for rebuild
+  /// on changes of that value.
   ///
   /// If [T] is nullable and no matching providers are found, [watch] will
   /// return `null`. Otherwise if [T] is non-nullable, will throw [ProviderNotFoundException].


### PR DESCRIPTION
The current description might make it seem like the `context.select()` extension is useless without an explicit rebuild (which a StatelessWidget can't do through setState()). I tried to make it more obvious that this is actually taken care of by the package.