### PR TITLE
chore: reset of error handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ coverage/
 
 # Directory created by dartdoc
 doc/api/
+
+# IntelliJ
+.idea/
+

--- a/test/inherited_provider_test.dart
+++ b/test/inherited_provider_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
@@ -2428,7 +2429,7 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       flutterErrors,
       contains(
         isA<FlutterErrorDetails>().having(
-              (e) => e.exception,
+          (e) => e.exception,
           'exception',
           isA<StateError>().having((s) => s.message, 'message', expected),
         ),
@@ -2459,7 +2460,7 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       flutterErrors,
       contains(
         isA<FlutterErrorDetails>().having(
-              (e) => e.exception,
+          (e) => e.exception,
           'exception',
           isA<StateError>().having((s) => s.message, 'message', expected),
         ),
@@ -2492,7 +2493,7 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       flutterErrors,
       contains(
         isA<FlutterErrorDetails>().having(
-              (e) => e.exception,
+          (e) => e.exception,
           'exception',
           exception,
         ),

--- a/test/inherited_provider_test.dart
+++ b/test/inherited_provider_test.dart
@@ -2422,18 +2422,20 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       ),
     );
 
-    expect(
-      flutterErrors,
-      contains(
-        isA<FlutterErrorDetails>().having(
-          (e) => e.exception,
-          'exception',
-          isA<StateError>().having((s) => s.message, 'message', expected),
+    try {
+      expect(
+        flutterErrors,
+        contains(
+          isA<FlutterErrorDetails>().having(
+                (e) => e.exception,
+            'exception',
+            isA<StateError>().having((s) => s.message, 'message', expected),
+          ),
         ),
-      ),
-    );
-
-    FlutterError.onError = onError;
+      );
+    } finally {
+      FlutterError.onError = onError;
+    }
   });
 
   testWidgets('StateError is thrown when exception occurs in create',
@@ -2453,18 +2455,20 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       ),
     );
 
-    expect(
-      flutterErrors,
-      contains(
-        isA<FlutterErrorDetails>().having(
-          (e) => e.exception,
-          'exception',
-          isA<StateError>().having((s) => s.message, 'message', expected),
+    try {
+      expect(
+        flutterErrors,
+        contains(
+          isA<FlutterErrorDetails>().having(
+                (e) => e.exception,
+            'exception',
+            isA<StateError>().having((s) => s.message, 'message', expected),
+          ),
         ),
-      ),
-    );
-
-    FlutterError.onError = onError;
+      );
+    } finally {
+      FlutterError.onError = onError;
+    }
   });
 
   testWidgets(
@@ -2486,18 +2490,20 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       ),
     );
 
-    expect(
-      flutterErrors,
-      contains(
-        isA<FlutterErrorDetails>().having(
-          (e) => e.exception,
-          'exception',
-          exception,
+    try {
+      expect(
+        flutterErrors,
+        contains(
+          isA<FlutterErrorDetails>().having(
+                (e) => e.exception,
+            'exception',
+            exception,
+          ),
         ),
-      ),
-    );
-
-    FlutterError.onError = onError;
+      );
+    } finally {
+      FlutterError.onError = onError;
+    }
   });
 }
 

--- a/test/inherited_provider_test.dart
+++ b/test/inherited_provider_test.dart
@@ -2422,20 +2422,18 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       ),
     );
 
-    try {
-      expect(
-        flutterErrors,
-        contains(
-          isA<FlutterErrorDetails>().having(
-                (e) => e.exception,
-            'exception',
-            isA<StateError>().having((s) => s.message, 'message', expected),
-          ),
+    FlutterError.onError = onError;
+
+    expect(
+      flutterErrors,
+      contains(
+        isA<FlutterErrorDetails>().having(
+              (e) => e.exception,
+          'exception',
+          isA<StateError>().having((s) => s.message, 'message', expected),
         ),
-      );
-    } finally {
-      FlutterError.onError = onError;
-    }
+      ),
+    );
   });
 
   testWidgets('StateError is thrown when exception occurs in create',
@@ -2455,20 +2453,18 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       ),
     );
 
-    try {
-      expect(
-        flutterErrors,
-        contains(
-          isA<FlutterErrorDetails>().having(
-                (e) => e.exception,
-            'exception',
-            isA<StateError>().having((s) => s.message, 'message', expected),
-          ),
+    FlutterError.onError = onError;
+
+    expect(
+      flutterErrors,
+      contains(
+        isA<FlutterErrorDetails>().having(
+              (e) => e.exception,
+          'exception',
+          isA<StateError>().having((s) => s.message, 'message', expected),
         ),
-      );
-    } finally {
-      FlutterError.onError = onError;
-    }
+      ),
+    );
   });
 
   testWidgets(
@@ -2490,20 +2486,18 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       ),
     );
 
-    try {
-      expect(
-        flutterErrors,
-        contains(
-          isA<FlutterErrorDetails>().having(
-                (e) => e.exception,
-            'exception',
-            exception,
-          ),
+    FlutterError.onError = onError;
+
+    expect(
+      flutterErrors,
+      contains(
+        isA<FlutterErrorDetails>().having(
+              (e) => e.exception,
+          'exception',
+          exception,
         ),
-      );
-    } finally {
-      FlutterError.onError = onError;
-    }
+      ),
+    );
   });
 }
 


### PR DESCRIPTION
Without resetting the Flutter error handler, the `WidgetTester`
will raise the following assertion error in case the `expect`
method raises a test failure:

```
'package:flutter_test/src/binding.dart': Failed assertion:
line 775 pos 14: '_pendingExceptionDetails != null': A test
overrode FlutterError.onError but either failed to return it to
its original state, or had unexpected additional errors that
it could not handle. Typically, this is caused by using expect()
before restoring FlutterError.onError.
```