### PR TITLE
Improve performance of `_inheritedElementOf`

### DIFF
--- a/lib/src/inherited_provider.dart
+++ b/lib/src/inherited_provider.dart
@@ -382,6 +382,8 @@ class _InheritedProviderScopeElement<T> extends InheritedElement
       getElementForInheritedWidgetOfExactType<T extends InheritedWidget>() {
     InheritedElement? inheritedElement;
 
+    // An InheritedProvider<T>'s update tries to obtain a parent provider of
+    // the same type.
     visitAncestorElements((parent) {
       inheritedElement = parent.getElementForInheritedWidgetOfExactType<T>();
       return false;

--- a/lib/src/inherited_provider.dart
+++ b/lib/src/inherited_provider.dart
@@ -378,14 +378,15 @@ class _InheritedProviderScopeElement<T> extends InheritedElement
   late String _debugId;
 
   @override
-  InheritedElement?
-      getElementForInheritedWidgetOfExactType<T extends InheritedWidget>() {
+  InheritedElement? getElementForInheritedWidgetOfExactType<
+      InheritedWidgetType extends InheritedWidget>() {
     InheritedElement? inheritedElement;
 
     // An InheritedProvider<T>'s update tries to obtain a parent provider of
     // the same type.
     visitAncestorElements((parent) {
-      inheritedElement = parent.getElementForInheritedWidgetOfExactType<T>();
+      inheritedElement =
+          parent.getElementForInheritedWidgetOfExactType<InheritedWidgetType>();
       return false;
     });
     return inheritedElement;

--- a/lib/src/inherited_provider.dart
+++ b/lib/src/inherited_provider.dart
@@ -378,6 +378,18 @@ class _InheritedProviderScopeElement<T> extends InheritedElement
   late String _debugId;
 
   @override
+  InheritedElement?
+      getElementForInheritedWidgetOfExactType<T extends InheritedWidget>() {
+    InheritedElement? inheritedElement;
+
+    visitAncestorElements((parent) {
+      inheritedElement = parent.getElementForInheritedWidgetOfExactType<T>();
+      return false;
+    });
+    return inheritedElement;
+  }
+
+  @override
   void mount(Element? parent, dynamic newSlot) {
     if (kDebugMode) {
       _debugId = '${_nextProviderId++}';

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -338,19 +338,11 @@ If you want to expose a variable that can be anything, consider changing
     );
     _InheritedProviderScopeElement<T?>? inheritedElement;
 
-    if (context.widget is _InheritedProviderScope<T?>) {
-      // An InheritedProvider<T>'s update tries to obtain a parent provider of
-      // the same type.
-      context.visitAncestorElements((parent) {
-        inheritedElement = parent.getElementForInheritedWidgetOfExactType<
-                _InheritedProviderScope<T?>>()
-            as _InheritedProviderScopeElement<T?>?;
-        return false;
-      });
-    } else {
-      inheritedElement = context.getElementForInheritedWidgetOfExactType<
+    context.visitAncestorElements((parent) {
+      inheritedElement = parent.getElementForInheritedWidgetOfExactType<
           _InheritedProviderScope<T?>>() as _InheritedProviderScopeElement<T?>?;
-    }
+      return false;
+    });
 
     if (inheritedElement == null && null is! T) {
       throw ProviderNotFoundException(T, context.widget.runtimeType);

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -336,10 +336,8 @@ If you want to expose a variable that can be anything, consider changing
 `dynamic` to `Object` instead.
 ''',
     );
-    _InheritedProviderScopeElement<T?>? inheritedElement =
-        context.getElementForInheritedWidgetOfExactType<
-                _InheritedProviderScope<T?>>()
-            as _InheritedProviderScopeElement<T?>?;
+    final inheritedElement = context.getElementForInheritedWidgetOfExactType<
+        _InheritedProviderScope<T?>>() as _InheritedProviderScopeElement<T?>?;
 
     if (inheritedElement == null && null is! T) {
       throw ProviderNotFoundException(T, context.widget.runtimeType);

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -336,13 +336,10 @@ If you want to expose a variable that can be anything, consider changing
 `dynamic` to `Object` instead.
 ''',
     );
-    _InheritedProviderScopeElement<T?>? inheritedElement;
-
-    context.visitAncestorElements((parent) {
-      inheritedElement = parent.getElementForInheritedWidgetOfExactType<
-          _InheritedProviderScope<T?>>() as _InheritedProviderScopeElement<T?>?;
-      return false;
-    });
+    _InheritedProviderScopeElement<T?>? inheritedElement =
+        context.getElementForInheritedWidgetOfExactType<
+                _InheritedProviderScope<T?>>()
+            as _InheritedProviderScopeElement<T?>?;
 
     if (inheritedElement == null && null is! T) {
       throw ProviderNotFoundException(T, context.widget.runtimeType);


### PR DESCRIPTION
We're looking into startup performance for a large flutter app - think deeply nested widget trees using `package:provider`. This is the specific line of interest:

https://github.com/rrousselGit/provider/blob/1fce240150fc098fc15cda61615a2fe0cea4c961/lib/src/provider.dart#L341

Zooming in on a startup CPU profile of Flutter's UI thread, we see that the `_inheritedElementOf` method takes 20ms.

![image](https://user-images.githubusercontent.com/7111741/165502514-35983181-6240-4199-b51e-1928404bcaad.png)


In the Dart VM implementation, `<obj> is <type>` checks with many different types for `<obj>` like this line at runtime is relatively expensive (cc @mkustermann). This shows up as `DRT_InstanceOf` in the above profile.

This is the same view of the CPU profile after applying this PR, showing that the runtime of `_inheritedElementOf` has halved and we no longer see those calls to `DRT_InstanceOf`.

![image](https://user-images.githubusercontent.com/7111741/165502624-1d35eeda-1c7b-4530-baea-6b8478f78afd.png)

Please let me know if I'm mistaken, but it appears that this conditional was previously added as an optimization to avoid calling [`visitAncestorElements`](https://api.flutter.dev/flutter/widgets/BuildContext/visitAncestorElements.html). This method does takes O(n) in the depth of the tree if we go through the tree in its entirety, but since we're returning `false` in the closure to find the parent, `visitAncestorElements` would terminate quickly in constant time and the optimization is not needed (and is in fact detrimental to performance due to the cost of the `is` check).