### PR TITLE
Release error messages

### DIFF
--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -441,6 +441,9 @@ class ProviderNullException implements Exception {
   final Type widgetType;
   @override
   String toString() {
+    if (kReleaseMode) {
+      return 'A provider for $valueType unexpectedly returned null.';
+    }
     return '''
 Error: The widget $widgetType tried to read Provider<$valueType> but the matching
 provider returned null.
@@ -467,6 +470,9 @@ class ProviderNotFoundException implements Exception {
 
   @override
   String toString() {
+    if (kReleaseMode) {
+      return 'Provider<$valueType> not found for $widgetType';
+    }
     return '''
 Error: Could not find the correct Provider<$valueType> above this $widgetType Widget
 


### PR DESCRIPTION
By default, Flutter replaces `toString` overrides on non-`Exception` or `Error` objects (unless a pragma is specified to keep them).

These types do not get shaken out because they're exceptions, and so the very helpful messages for developers end up in release binaries (and possibly logs) for end users.

This patch guards the longer strings in release mode and replaces them with terser versions that are slightly less helpful. It marginally reduces binary size.