### PR TITLE
Add issue_tracker link for pub.dev

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: provider
 description: A wrapper around InheritedWidget to make them easier to use and more reusable.
 version: 6.0.3
 repository: https://github.com/rrousselGit/provider
+issue_tracker: https://github.com/rrousselGit/provider/issues
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This PR adds a link to GitHub issues to pub.dev (in the right column right under the repository link).