### PR TITLE
Make tests less fragile

### DIFF
--- a/test/inherited_provider_test.dart
+++ b/test/inherited_provider_test.dart
@@ -554,7 +554,7 @@ The context used was: Context
         ),
       );
 
-      final rootElement = tester.allElements.first;
+      final rootElement = tester.element(find.bySubtype<InheritedProvider>());
 
       expect(
         rootElement.toString(),
@@ -583,7 +583,7 @@ The context used was: Context
         ),
       );
 
-      final rootElement = tester.allElements.first;
+      final rootElement = tester.element(find.bySubtype<InheritedProvider>());
 
       expect(
         rootElement.toString(),
@@ -607,7 +607,7 @@ The context used was: Context
         ),
       );
 
-      final rootElement = tester.allElements.first;
+      final rootElement = tester.element(find.bySubtype<InheritedProvider>());
 
       expect(
         rootElement.toString(),
@@ -634,7 +634,7 @@ The context used was: Context
         ),
       );
 
-      final rootElement = tester.allElements.first;
+      final rootElement = tester.element(find.bySubtype<DeferredInheritedProvider>());
 
       expect(
         rootElement.toString(),
@@ -665,7 +665,7 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
         ),
       );
 
-      final rootElement = tester.allElements.first;
+      final rootElement = tester.element(find.bySubtype<InheritedProvider>());
 
       expect(
         rootElement.toString(),


### PR DESCRIPTION
In https://github.com/flutter/flutter/pull/116924 Flutter is changing the shape of the root of the widget tree, which caused some of the provider tests run as part of the "Flutter Customer Test Registry" [1] to fail. These tests were making some assumptions about the root of the widget tree. This PR refactors those tests to remove that assumption, which wasn't necessary to test the specified functionality.

[1] https://github.com/flutter/tests/blob/main/registry/provider.test