### PR TITLE
Explicitly provide type parameters.

### DIFF
--- a/lib/src/devtool.dart
+++ b/lib/src/devtool.dart
@@ -60,13 +60,13 @@ class ProviderNode {
     required this.id,
     required this.childrenNodeIds,
     required this.type,
-    required _InheritedProviderScopeElement element,
+    required _InheritedProviderScopeElement<Object?> element,
   }) : _element = element;
 
   final String id;
   final String type;
   final List<String> childrenNodeIds;
-  final _InheritedProviderScopeElement _element;
+  final _InheritedProviderScopeElement<Object?> _element;
 
   Object? get value => _element._delegateState.value;
 }

--- a/lib/src/listenable_provider.dart
+++ b/lib/src/listenable_provider.dart
@@ -55,7 +55,7 @@ class ListenableProvider<T extends Listenable?> extends InheritedProvider<T> {
         );
 
   static VoidCallback _startListening(
-    InheritedContext e,
+    InheritedContext<Listenable?> e,
     Listenable? value,
   ) {
     value?.addListener(e.markNeedsNotifyDependents);

--- a/test/null_safe/common.dart
+++ b/test/null_safe/common.dart
@@ -26,7 +26,7 @@ Type typeOf<T>() => T;
 ///
 /// For use in legacy tests: they can't instantiate a `Provider<T?>` directly
 /// because they can't write `<T?>`. But, they can pass around a `Provider<T?`>.
-Provider<T?> nullableProviderOfValue<T>(T value, Provider? child) =>
+Provider<T?> nullableProviderOfValue<T>(T value, Provider<dynamic>? child) =>
     Provider<T?>.value(
       value: value,
       child: child,
@@ -35,7 +35,7 @@ Provider<T?> nullableProviderOfValue<T>(T value, Provider? child) =>
 /// Given `T`, returns a `Provider<T>`.
 ///
 /// For legacy tests to get a `Provider<T>`.
-Provider<T> nullSafeProviderOfValue<T>(T value, Provider? child) =>
+Provider<T> nullSafeProviderOfValue<T>(T value, Provider<dynamic>? child) =>
     Provider<T>.value(
       value: value,
       child: child,


### PR DESCRIPTION
This is an info diagnostic that will soon become a warning.

See https://github.com/flutter/flutter/issues/120992