### PR TITLE
Provider Extensions

### DIFF
--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 6.1.0-dev.2
+
+- Provider Extensions added: 
+  1. ProviderExtension:
+     - provideProvider
+     - provideProviderValue
+  2. MultiProviderExtension:
+     - provideMultiProvider
+  3. ChangeNotifierProviderExtension:
+     - provideChangeNotifierProvider
+     - provideChangeNotifierProviderValue
+
 ## 6.1.0-dev.1
 
 - Fix missing folder in devtool extension

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -688,6 +688,83 @@ The complete list of all the objects available is [here](https://pub.dev/documen
 | [StreamProvider](https://pub.dartlang.org/documentation/provider/latest/provider/StreamProvider-class.html)                   | Listen to a Stream and expose the latest value emitted.                                                                                                                |
 | [FutureProvider](https://pub.dartlang.org/documentation/provider/latest/provider/FutureProvider-class.html)                   | Takes a `Future` and updates dependents when the future completes.                                                                                                     |
 
+### Provider Extensions
+
+Provider Extensions are a set of extension methods on the Widget class that allow any widget to be easily wrapped with various types of providers, such as Provider, MultiProvider, and ChangeNotifierProvider. These extensions help to reduce boilerplate code and make the code more readable.
+
+1. ProviderExtension:
+   - provideProvider
+   - provideProviderValue
+2. MultiProviderExtension:
+   - provideMultiProvider
+3. ChangeNotifierProviderExtension:
+   - provideChangeNotifierProvider
+   - provideChangeNotifierProviderValue
+
+#### Provider without extension
+
+```dart
+Provider<MyObject>(
+  create: (_) => MyObject(),
+  child: MyWidget(),
+);
+```
+
+#### Provider with extension
+
+
+```dart
+MyWidget().provideProvider(
+  create: (_) => MyObject(),
+);
+```
+
+#### ChangeNotifierProvider.value without extension
+
+```dart
+MyChangeNotifier myChangeNotifier = MyChangeNotifier();
+
+ChangeNotifierProvider<MyChangeNotifier>.value(
+  value: myChangeNotifier,
+  child: MyWidget(),
+);
+```
+
+#### ChangeNotifierProvider.value with extension
+
+```dart
+MyChangeNotifier myChangeNotifier = MyChangeNotifier();
+
+MyWidget().provideChangeNotifierProviderValue(
+  value: myChangeNotifier,
+);
+```
+
+#### MultiProvider without extension
+
+```dart
+MultiProvider(
+  providers: [
+    Provider<MyObject>(create: (_) => MyObject()),
+    Provider<MyOtherObject>(create: (_) => MyOtherObject()),
+  ],
+  child: MyWidget(),
+);
+```
+
+#### MultiProvider with extension
+
+```dart
+MyWidget().provideMultiProvider(
+  providers: [
+    Provider<MyObject>(create: (_) => MyObject()),
+    Provider<MyOtherObject>(create: (_) => MyOtherObject()),
+  ],
+);
+```
+
+
+
 ### My application throws a StackOverflowError because I have too many providers, what can I do?
 
 If you have a very large number of providers (150+), it is possible that some devices will throw a `StackOverflowError` because you end-up building too many widgets at once.

--- a/packages/provider/lib/provider.dart
+++ b/packages/provider/lib/provider.dart
@@ -5,6 +5,7 @@ export 'src/async_provider.dart'
 export 'src/change_notifier_provider.dart'
     show
         ChangeNotifierProvider,
+        ChangeNotifierProviderExtension,
         ChangeNotifierProxyProvider,
         ChangeNotifierProxyProvider0,
         ChangeNotifierProxyProvider2,
@@ -39,6 +40,8 @@ export 'src/provider.dart'
         Dispose,
         Locator,
         ReadContext,
+        ProviderExtension,
+        MultiProviderExtension,
         SelectContext,
         StartListening,
         UpdateShouldNotify,

--- a/packages/provider/lib/src/change_notifier_provider.dart
+++ b/packages/provider/lib/src/change_notifier_provider.dart
@@ -361,3 +361,82 @@ class ChangeNotifierProxyProvider6<T, T2, T3, T4, T5, T6,
           child: child,
         );
 }
+
+/// Extension on [Widget] to provide a [ChangeNotifierProvider].
+///
+/// This extension methods allows any [Widget] to be wrapped with a [ChangeNotifierProvider]
+/// or a [ChangeNotifierProvider.value].
+///
+/// Example usage:
+/// ```dart
+/// MyWidget().provideChangeNotifierProvider(
+///   create: (_) => MyChangeNotifier(),
+///   lazy: false,
+///   key: Key('MyChangeNotifierProvider'),
+/// );
+/// ```
+extension ChangeNotifierProviderExtension on Widget {
+  /// Wraps the widget with a [ChangeNotifierProvider].
+  ///
+  /// Parameters:
+  /// * [create]: A function that creates the [ChangeNotifier].
+  /// * [lazy]: An optional parameter to control the laziness of the provider. Defaults to true.
+  /// * [builder]: An optional parameter for custom transitions.
+  /// * [key]: An optional parameter for identifying the provider.
+  ///
+  /// Returns: The widget wrapped with a [ChangeNotifierProvider].
+  ///
+  /// Example usage:
+  /// ```dart
+  /// MyWidget().provideChangeNotifierProvider(
+  ///   create: (_) => MyChangeNotifier(),
+  ///   lazy: false,
+  ///   key: Key('MyChangeNotifierProvider'),
+  /// );
+  /// ```
+  Widget provideChangeNotifierProvider<T extends ChangeNotifier>({
+    required Create<T> create,
+    Key? key,
+    bool? lazy,
+    TransitionBuilder? builder,
+  }) {
+    return ChangeNotifierProvider<T>(
+      key: key,
+      create: create,
+      lazy: lazy,
+      builder: builder,
+      child: this,
+    );
+  }
+
+  /// Wraps the widget with a [ChangeNotifierProvider.value].
+  ///
+  /// Parameters:
+  /// * [value]: The [ChangeNotifier] to provide.
+  /// * [builder]: An optional parameter for custom transitions.
+  /// * [key]: An optional parameter for identifying the provider.
+  ///
+  /// Returns: The widget wrapped with a [ChangeNotifierProvider.value].
+  ///
+  /// Example usage:
+  /// ```dart
+  /// MyChangeNotifier myChangeNotifier = MyChangeNotifier();
+  ///
+  /// MyWidget().provideChangeNotifierProviderValue(
+  ///   value: MyChangeNotifier,
+  ///   key: Key('MyChangeNotifierProvider'),
+  /// );
+  /// ```
+  Widget provideChangeNotifierProviderValue<T extends ChangeNotifier>({
+    required T value,
+    Key? key,
+    TransitionBuilder? builder,
+  }) {
+    return ChangeNotifierProvider<T>.value(
+      key: key,
+      value: value,
+      builder: builder,
+      child: this,
+    );
+  }
+}

--- a/packages/provider/lib/src/provider.dart
+++ b/packages/provider/lib/src/provider.dart
@@ -694,6 +694,137 @@ extension WatchContext on BuildContext {
   }
 }
 
+/// Extension on [Widget] to provide a [Provider].
+///
+/// This extension methods allows any [Widget] to be wrapped with a [Provider].
+///
+/// Example usage:
+/// ```dart
+/// MyWidget().provideProvider(
+///   create: (_) => MyObject(),
+/// );
+/// ```
+extension ProviderExtension on Widget {
+  /// Wraps the widget with a [Provider].
+  ///
+  /// Parameters:
+  /// * [create]: A function that creates the object.
+  /// * [dispose]: A function that disposes the object.
+  /// * [key]: An optional parameter for identifying the provider.
+  /// * [lazy]: An optional parameter to control the laziness of the provider. Defaults to true.
+  /// * [builder]: An optional parameter for custom transitions.
+  ///
+  /// Returns: The widget wrapped with a [Provider].
+  ///
+  /// Example usage:
+  /// ```dart
+  /// MyWidget().provideProvider(
+  ///   create: (_) => MyObject(),
+  ///   lazy: false,
+  ///   key: Key('MyProvider'),
+  /// );
+  /// ```
+  Widget provideProvider<T>({
+    Key? key,
+    required Create<T> create,
+    Dispose<T>? dispose,
+    bool? lazy,
+    TransitionBuilder? builder,
+  }) {
+    return Provider<T>(
+      key: key,
+      create: create,
+      dispose: dispose,
+      lazy: lazy,
+      builder: builder,
+      child: this,
+    );
+  }
+
+  /// Wraps the widget with a [Provider.value].
+  ///
+  /// Parameters:
+  /// * [value]: The value to provide.
+  /// * [updateShouldNotify]: An optional parameter to avoid unnecessarily
+  /// rebuilding dependents when [Provider] is rebuilt but `value` did not change.
+  /// * [builder]: An optional parameter for custom transitions.
+  /// * [key]: An optional parameter for identifying the provider.
+  ///
+  /// Returns: The widget wrapped with a [Provider.value].
+  ///
+  /// Example usage:
+  /// ```dart
+  /// MyObject myObject = MyObject();
+  ///
+  /// MyWidget().provideProviderValue(
+  ///   value: myObject,
+  ///   key: Key('MyProvider'),
+  /// );
+  /// ```
+  Widget provideProviderValue<T>({
+    required T value,
+    Key? key,
+    UpdateShouldNotify<T>? updateShouldNotify,
+    TransitionBuilder? builder,
+  }) {
+    return Provider<T>.value(
+      key: key,
+      value: value,
+      updateShouldNotify: updateShouldNotify,
+      builder: builder,
+      child: this,
+    );
+  }
+}
+
+/// Extension on [Widget] to provide a [MultiProvider].
+///
+/// This extension methods allows any [Widget] to be wrapped with a [MultiProvider].
+///
+/// Example usage:
+/// ```dart
+/// MyWidget().provideMultiProvider(
+///   providers: [
+///     Provider<MyObject>(create: (_) => MyObject()),
+///     Provider<MyOtherObject>(create: (_) => MyOtherObject()),
+///   ],
+/// );
+/// ```
+extension MultiProviderExtension on Widget {
+  /// Wraps the widget with a [MultiProvider].
+  ///
+  /// Parameters:
+  /// * [providers]: A list of providers to be provided to the widget tree.
+  /// * [key]: An optional parameter for identifying the provider.
+  /// * [builder]: An optional parameter for custom transitions.
+  ///
+  /// Returns: The widget wrapped with a [MultiProvider].
+  ///
+  /// Example usage:
+  /// ```dart
+  /// MyWidget().provideMultiProvider(
+  ///   providers: [
+  ///     Provider<MyObject>(create: (_) => MyObject()),
+  ///     Provider<MyOtherObject>(create: (_) => MyOtherObject()),
+  ///   ],
+  ///   key: Key('MyMultiProvider'),
+  /// );
+  /// ```
+  Widget provideMultiProvider({
+    required List<SingleChildWidget> providers,
+    Key? key,
+    TransitionBuilder? builder,
+  }) {
+    return MultiProvider(
+      key: key,
+      providers: providers,
+      builder: builder,
+      child: this,
+    );
+  }
+}
+
+
 /// A generic function that can be called to read providers, without having a
 /// reference on [BuildContext].
 ///

--- a/packages/provider/pubspec.yaml
+++ b/packages/provider/pubspec.yaml
@@ -1,6 +1,6 @@
 name: provider
 description: A wrapper around InheritedWidget to make them easier to use and more reusable.
-version: 6.1.0-dev.1
+version: 6.1.0-dev.2
 repository: https://github.com/rrousselGit/provider
 issue_tracker: https://github.com/rrousselGit/provider/issues
 


### PR DESCRIPTION
# Provider Extensions Update

Hey @rrousselGit, first of all thank you for the great packages that makes flutter devs live easier 😊 

This PR adds the `Provider Extensions` to the `Widget` class. These extensions have been introduced as an alternative syntactic sugar for providing providers. While they offer a streamlined approach that can reduce boilerplate in certain scenarios, they're intended to complement existing methods rather than replace them, thereby giving developers more flexibility in how they structure their code.

## Additions:
What I have added; 

### ProviderExtension

    provideProvider: Equivalent for Provider.
    provideProviderValue: Equivalent for Provider.value.

### MultiProviderExtension:

    provideMultiProvider: Equivalent for MultiProvider.

### ChangeNotifierProviderExtension:

    provideChangeNotifierProvider: Equivalent for ChangeNotifierProvider.
    provideChangeNotifierProviderValue: Equivalent for ChangeNotifierProvider.value.

## Example:

Traditional Provider:
```dart
Provider<MyObject>(
  create: (_) => MyObject(),
  child: MyWidget(),
);
```

Using ProviderExtension:
```dart
MyWidget().provideProvider(
  create: (_) => MyObject(),
);
```

Feedback is welcome. Please review the changes and share any suggestions or concerns.

Thank you,
Onat Cipli

