### PR TITLE
docs: change selector example from tuple to records

### DIFF
--- a/packages/provider/lib/src/selector.dart
+++ b/packages/provider/lib/src/selector.dart
@@ -119,6 +119,22 @@ class _Selector0State<T> extends SingleChildState<Selector0<T>> {
 /// As such, it `selector` should return either a collection ([List]/[Map]/[Set]/[Iterable])
 /// or a class that override `==`.
 ///
+/// Here's an example:
+///
+/// Example 1:
+///
+///```dart
+/// Selector<Foo, Bar>(
+///   selector: (_, foo) => foo.bar,  // will rebuild only when `bar` changes
+///   builder: (_, data, __) {
+///     return Text('${data.item}');
+///   }
+/// )
+///```
+///In this example `builder` will be called only when `foo.bar` changes.
+///
+/// Example 2:
+///
 ///To select multiple values without having to write a class that implements `==`,
 ///the easiest solution is to use "Records," available from Dart version 3.0.
 ///For more information on Records, refer to the [records](https://dart.dev/language/records).
@@ -132,7 +148,7 @@ class _Selector0State<T> extends SingleChildState<Selector0<T>> {
 /// );
 /// ```
 ///
-/// In that example, `builder` will be called again only if `foo.item1` or
+/// In this example, `builder` will be called again only if `foo.item1` or
 /// `foo.item2` changes.
 ///
 /// For generic usage information, see [Consumer].

--- a/packages/provider/lib/src/selector.dart
+++ b/packages/provider/lib/src/selector.dart
@@ -135,9 +135,9 @@ class _Selector0State<T> extends SingleChildState<Selector0<T>> {
 ///
 /// Example 2:
 ///
-///To select multiple values without having to write a class that implements `==`,
-///the easiest solution is to use "Records," available from Dart version 3.0.
-///For more information on Records, refer to the [records](https://dart.dev/language/records).
+/// To select multiple values without having to write a class that implements `==`,
+/// the easiest solution is to use "Records," available from Dart version 3.0.
+/// For more information on Records, refer to the [records](https://dart.dev/language/records).
 ///
 /// ```dart
 /// Selector<Foo, ({String item1, String item2})>(

--- a/packages/provider/lib/src/selector.dart
+++ b/packages/provider/lib/src/selector.dart
@@ -119,20 +119,21 @@ class _Selector0State<T> extends SingleChildState<Selector0<T>> {
 /// As such, it `selector` should return either a collection ([List]/[Map]/[Set]/[Iterable])
 /// or a class that override `==`.
 ///
-/// To select multiple values without having to write a class that implements `==`,
-/// the easiest solution is to use a "Tuple" from [tuple](https://pub.dev/packages/tuple):
+///To select multiple values without having to write a class that implements `==`,
+///the easiest solution is to use "Records," available from Dart version 3.0.
+///For more information on Records, refer to the [records](https://dart.dev/language/records).
 ///
 /// ```dart
-/// Selector<Foo, Tuple2<Bar, Baz>>(
-///   selector: (_, foo) => Tuple2(foo.bar, foo.baz),
+/// Selector<Foo, ({String item1, String item2})>(
+///   selector: (_, foo) => (item1: foo.item1, item2: foo.item2),
 ///   builder: (_, data, __) {
 ///     return Text('${data.item1}  ${data.item2}');
-///   }
-/// )
+///   },
+/// );
 /// ```
 ///
-/// In that example, `builder` will be called again only if `foo.bar` or
-/// `foo.baz` changes.
+/// In that example, `builder` will be called again only if `foo.item1` or
+/// `foo.item2` changes.
 ///
 /// For generic usage information, see [Consumer].
 /// {@endtemplate}


### PR DESCRIPTION
1. This PR closes [830](https://github.com/rrousselGit/provider/issues/830): Change Selector example doc from tuple to dart Records as current recommendation is to use records. 
2. This PR also closes [712](https://github.com/rrousselGit/provider/issues/712) by adding more example for Selector