### PR TITLE
Wrap dev tools extension screen with SelectionArea

### DIFF
--- a/packages/provider_devtools_extension/lib/src/provider_screen.dart
+++ b/packages/provider_devtools_extension/lib/src/provider_screen.dart
@@ -54,58 +54,60 @@ class ProviderScreenBody extends ConsumerWidget {
       if (hasError) showProviderErrorBanner();
     });
 
-    return Split(
-      axis: splitAxis,
-      initialFractions: const [0.33, 0.67],
-      children: [
-        const RoundedOutlinedBorder(
-          clip: true,
-          child: Column(
-            children: [
-              AreaPaneHeader(
-                roundedTopBorder: false,
-                includeTopBorder: false,
-                title: Text('Providers'),
-              ),
-              Expanded(
-                child: ProviderList(),
-              ),
-            ],
-          ),
-        ),
-        RoundedOutlinedBorder(
-          clip: true,
-          child: Column(
-            children: [
-              AreaPaneHeader(
-                roundedTopBorder: false,
-                includeTopBorder: false,
-                title: Text(detailsTitleText),
-                actions: [
-                  IconButton(
-                    icon: const Icon(Icons.settings),
-                    onPressed: () {
-                      unawaited(
-                        showDialog(
-                          context: context,
-                          builder: (_) => _StateInspectorSettingsDialog(),
-                        ),
-                      );
-                    },
-                  ),
-                ],
-              ),
-              if (selectedProviderId != null)
-                Expanded(
-                  child: InstanceViewer(
-                    rootPath: InstancePath.fromProviderId(selectedProviderId),
-                    showInternalProperties: ref.watch(_showInternals),
-                  ),
+    return SelectionArea(
+      child: Split(
+        axis: splitAxis,
+        initialFractions: const [0.33, 0.67],
+        children: [
+          const RoundedOutlinedBorder(
+            clip: true,
+            child: Column(
+              children: [
+                AreaPaneHeader(
+                  roundedTopBorder: false,
+                  includeTopBorder: false,
+                  title: Text('Providers'),
                 ),
-            ],
+                Expanded(
+                  child: ProviderList(),
+                ),
+              ],
+            ),
           ),
-        ),
-      ],
+          RoundedOutlinedBorder(
+            clip: true,
+            child: Column(
+              children: [
+                AreaPaneHeader(
+                  roundedTopBorder: false,
+                  includeTopBorder: false,
+                  title: Text(detailsTitleText),
+                  actions: [
+                    IconButton(
+                      icon: const Icon(Icons.settings),
+                      onPressed: () {
+                        unawaited(
+                          showDialog(
+                            context: context,
+                            builder: (_) => _StateInspectorSettingsDialog(),
+                          ),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+                if (selectedProviderId != null)
+                  Expanded(
+                    child: InstanceViewer(
+                      rootPath: InstancePath.fromProviderId(selectedProviderId),
+                      showInternalProperties: ref.watch(_showInternals),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
By wrapping the dev tools screen with `SelectionArea` it's now possible to select text and that way copy the current values or names of providers.

@rrousselGit There is no guidance on what I have to do if I want to contribute. Please let me know if there is anything more to do to ship this or just do it by yourself, that's fine for me as well.