### PR TITLE
Introducing Provider.shared for Efficient SharedInstance Management

### DIFF
--- a/packages/provider/lib/src/inherited_provider.dart
+++ b/packages/provider/lib/src/inherited_provider.dart
@@ -95,9 +95,9 @@ class InheritedProvider<T> extends SingleChildStatelessWidget {
         ),
         super(key: key, child: child);
 
-  InheritedProvider.sharedInstance({
+  InheritedProvider.shared({
     Key? key,
-    required Create<T> createInstance,
+    required Create<T> create,
     StartListening<T>? startListening,
     Dispose<T>? dispose,
     String? instanceKey,
@@ -105,8 +105,8 @@ class InheritedProvider<T> extends SingleChildStatelessWidget {
     this.builder,
     Widget? child,
   })  : _lazy = lazy,
-        _delegate = _SharedInstanceInheritedProvider(
-          create: createInstance,
+        _delegate = _SharedInheritedProvider(
+          create: create,
           startListening: startListening,
           dispose: dispose,
           instanceKey: instanceKey,
@@ -994,8 +994,8 @@ class _ValueInheritedProviderState<T>
   bool get hasValue => true;
 }
 
-class _SharedInstanceInheritedProvider<T> extends _CreateInheritedProvider<T> {
-  _SharedInstanceInheritedProvider({
+class _SharedInheritedProvider<T> extends _CreateInheritedProvider<T> {
+  _SharedInheritedProvider({
     required Create<T> create,
     this.instanceKey,
     StartListening<T>? startListening,
@@ -1009,13 +1009,13 @@ class _SharedInstanceInheritedProvider<T> extends _CreateInheritedProvider<T> {
   final String? instanceKey;
 
   @override
-  _SharedInstanceInheritedProviderState<T> createState() =>
-      _SharedInstanceInheritedProviderState<T>();
+  _SharedInheritedProviderState<T> createState() =>
+      _SharedInheritedProviderState<T>();
 }
 
-class _SharedInstanceInheritedProviderState<T>
+class _SharedInheritedProviderState<T>
     extends _CreateInheritedProviderState<T,
-        _SharedInstanceInheritedProvider<T>> {
+        _SharedInheritedProvider<T>> {
   SharedInstance<T>? _sharedInstance;
 
   String get _instanceKey => delegate.instanceKey ?? T.toString();

--- a/packages/provider/lib/src/provider.dart
+++ b/packages/provider/lib/src/provider.dart
@@ -253,19 +253,25 @@ class Provider<T> extends InheritedProvider<T> {
           child: child,
         );
 
-  Provider.sharedInstance({
+  /// Creates a value, store it, and expose it to its descendants.
+  /// Will also share it with other providers by value type or instanceKey.
+  ///
+  /// The value can be optionally disposed using [dispose] callback.
+  /// This callback that will be called when the last [Provider]
+  /// using the shared instance is unmounted from the widget tree.
+  Provider.shared({
     Key? key,
-    required Create<T> createInstance,
+    required Create<T> create,
     String? instanceKey,
     Dispose<T>? dispose,
     bool? lazy,
     TransitionBuilder? builder,
     Widget? child,
-  }) : super.sharedInstance(
+  }) : super.shared(
           key: key,
           lazy: lazy,
           builder: builder,
-          createInstance: createInstance,
+          create: create,
           instanceKey: instanceKey,
           dispose: dispose,
           child: child,

--- a/packages/provider/lib/src/provider.dart
+++ b/packages/provider/lib/src/provider.dart
@@ -10,6 +10,7 @@ import 'package:flutter/widgets.dart';
 import 'package:nested/nested.dart';
 
 import 'reassemble_handler.dart';
+import 'shared_instance.dart';
 
 part 'deferred_inherited_provider.dart';
 part 'devtool.dart';
@@ -249,6 +250,24 @@ class Provider<T> extends InheritedProvider<T> {
           builder: builder,
           value: value,
           updateShouldNotify: updateShouldNotify,
+          child: child,
+        );
+
+  Provider.sharedInstance({
+    Key? key,
+    required Create<T> createInstance,
+    String? instanceKey,
+    Dispose<T>? dispose,
+    bool? lazy,
+    TransitionBuilder? builder,
+    Widget? child,
+  }) : super.sharedInstance(
+          key: key,
+          lazy: lazy,
+          builder: builder,
+          createInstance: createInstance,
+          instanceKey: instanceKey,
+          dispose: dispose,
           child: child,
         );
 

--- a/packages/provider/lib/src/shared_instance.dart
+++ b/packages/provider/lib/src/shared_instance.dart
@@ -1,0 +1,57 @@
+typedef CreateValue<T> = T Function();
+
+class SharedInstance<T> {
+  SharedInstance._({
+    required this.value,
+    required Object acquirer,
+    required String instanceKey,
+  }) : _instanceKey = instanceKey {
+    _acquirers.add(acquirer);
+  }
+
+  final String _instanceKey;
+
+  final T value;
+
+  final Set<Object> _acquirers = {};
+
+  static final _container = <String, SharedInstance<dynamic>>{};
+
+  ///
+  /// Creates and returns an instance if it does not exist in the container.
+  /// Otherwise, returns an existing instance.
+  /// The acquirer is added to the list of acquirers.
+  ///
+  static SharedInstance<T> acquire<T>({
+    required CreateValue<T> createValue,
+    required Object acquirer,
+    String? instanceKey,
+  }) {
+    final key = instanceKey ?? T.toString();
+
+    if (!_container.containsKey(key)) {
+      _container[key] = SharedInstance<T>._(
+        value: createValue(),
+        acquirer: acquirer,
+        instanceKey: key,
+      );
+    }
+    return _container[key]! as SharedInstance<T>;
+  }
+
+  ///
+  /// Releases the instance from the acquirer.
+  /// If the instance is no longer used, it is removed from the container.
+  /// Returns true if the instance has been removed from the container.
+  /// Returns false if the instance remains in the container.
+  ///
+  bool release(Object acquirer) {
+    _acquirers.remove(acquirer);
+    var disposed = false;
+    if (_acquirers.isEmpty) {
+      _container.remove(_instanceKey);
+      disposed = true;
+    }
+    return disposed;
+  }
+}

--- a/packages/provider/test/null_safe/inherited_provider_test.dart
+++ b/packages/provider/test/null_safe/inherited_provider_test.dart
@@ -931,7 +931,7 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
     });
   });
 
-  group('InheritedProvider.sharedInstance()', () {
+  group('InheritedProvider.shared()', () {
     testWidgets('One instance for [type] shared between InheritedProvider',
         (tester) async {
       const firstInstance = 1;
@@ -946,8 +946,8 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       );
 
       final children = <Widget>[
-        InheritedProvider<int>.sharedInstance(
-          createInstance: (BuildContext context) {
+        InheritedProvider<int>.shared(
+          create: (BuildContext context) {
             return firstInstance;
           },
           child: consumer,
@@ -960,8 +960,8 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
 
       expect(value, equals(firstInstance));
 
-      children.add(InheritedProvider<int>.sharedInstance(
-        createInstance: (BuildContext context) {
+      children.add(InheritedProvider<int>.shared(
+        create: (BuildContext context) {
           return secondInstance;
         },
         child: consumer,
@@ -988,9 +988,9 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       );
 
       final children = <Widget>[
-        InheritedProvider<int>.sharedInstance(
+        InheritedProvider<int>.shared(
           instanceKey: 'firstInstanceKey',
-          createInstance: (BuildContext context) {
+          create: (BuildContext context) {
             return firstInstance;
           },
           child: consumer,
@@ -1003,9 +1003,9 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
 
       expect(value, equals(firstInstance));
 
-      children.add(InheritedProvider<int>.sharedInstance(
+      children.add(InheritedProvider<int>.shared(
         instanceKey: 'firstInstanceKey',
-        createInstance: (BuildContext context) {
+        create: (BuildContext context) {
           return secondInstance;
         },
         child: consumer,
@@ -1032,9 +1032,9 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       );
 
       final children = <Widget>[
-        InheritedProvider<int>.sharedInstance(
+        InheritedProvider<int>.shared(
           instanceKey: 'firstInstanceKey',
-          createInstance: (BuildContext context) {
+          create: (BuildContext context) {
             return firstInstance;
           },
           child: consumer,
@@ -1047,9 +1047,9 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
 
       expect(value, equals(firstInstance));
 
-      children.add(InheritedProvider<int>.sharedInstance(
+      children.add(InheritedProvider<int>.shared(
         instanceKey: 'secondInstanceKey',
-        createInstance: (BuildContext context) {
+        create: (BuildContext context) {
           return secondInstance;
         },
         child: consumer,
@@ -1072,15 +1072,15 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       int createInstance(_) => 1;
 
       final children = <Widget>[
-        InheritedProvider<int>.sharedInstance(
+        InheritedProvider<int>.shared(
           instanceKey: 'instanceKey',
-          createInstance: createInstance,
+          create: createInstance,
           dispose: firstDispose,
           child: consumer,
         ),
-        InheritedProvider<int>.sharedInstance(
+        InheritedProvider<int>.shared(
           instanceKey: 'instanceKey',
-          createInstance: createInstance,
+          create: createInstance,
           dispose: secondDispose,
           child: consumer,
         ),
@@ -1109,15 +1109,15 @@ DeferredInheritedProvider<int, int>(controller: 42, value: 24)'''),
       int createInstance(_) => 1;
 
       final children = <Widget>[
-        InheritedProvider<int>.sharedInstance(
+        InheritedProvider<int>.shared(
           instanceKey: 'instanceKey',
-          createInstance: createInstance,
+          create: createInstance,
           dispose: firstDispose,
           child: consumer,
         ),
-        InheritedProvider<int>.sharedInstance(
+        InheritedProvider<int>.shared(
           instanceKey: 'instanceKey',
-          createInstance: createInstance,
+          create: createInstance,
           dispose: secondDispose,
           child: consumer,
         ),

--- a/packages/provider/test/null_safe/shared_instance_test.dart
+++ b/packages/provider/test/null_safe/shared_instance_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/src/shared_instance.dart';
+
+void main() {
+  group('SharedInstance', () {
+
+    tearDown(SharedInstance.disposeAll);
+
+    test('acquire creates a new instance if it does not exist', () {
+      final instance = SharedInstance.acquire(
+        createValue: () => 1,
+        acquirer: Object(),
+        instanceKey: 'instanceKey',
+      );
+
+      expect(instance.value, equals(1));
+    });
+
+    test('acquire returns an existing instance if it exists', () {
+      final acquirer = Object();
+      final instance1 = SharedInstance.acquire(
+        createValue: () => 1,
+        acquirer: acquirer,
+        instanceKey: 'instanceKey',
+      );
+
+      final instance2 = SharedInstance.acquire(
+        createValue: () => 2,
+        acquirer: acquirer,
+        instanceKey: 'instanceKey',
+      );
+
+      expect(instance1, equals(instance2));
+    });
+
+    test('release removes the instance if it is no longer used', () {
+      final acquirer = Object();
+      final instance = SharedInstance.acquire(
+        createValue: () => 1,
+        acquirer: acquirer,
+        instanceKey: 'instanceKey',
+      );
+
+      final isRemoved = instance.release(acquirer);
+
+      expect(isRemoved, isTrue);
+    });
+
+    test('release does not remove the instance if it is still used', () {
+      final acquirer1 = Object();
+      final acquirer2 = Object();
+      final instance = SharedInstance.acquire(
+        createValue: () => 1,
+        acquirer: acquirer1,
+        instanceKey: 'instanceKey',
+      );
+      SharedInstance.acquire(
+        createValue: () => 1,
+        acquirer: acquirer2,
+        instanceKey: 'instanceKey',
+      );
+
+      final isRemoved = instance.release(acquirer1);
+
+      expect(isRemoved, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
### Problem

In the current implementation of the application with navigation between screens, there is a need to use the same instance (e.g., state management or service) on different screens, such as `ScreenA` and `ScreenB`. The approach that involves creating an instance at a level above `MaterialApp` results in the instance remaining in memory throughout the application's lifecycle, which is not optimal given its limited use.

Passing data between screens via navigation arguments is limited and not always suitable for working with complex data structures or in the context of declarative navigation.

### Solution

A proposed approach involves using a shared repository (`SharedInstances`) for temporarily storing and subsequently reusing instances. This repository will automatically delete unused instances, freeing up resources.

**Mechanism:**

1. On `ScreenA`, an instance is created and registered in `SharedInstances`.
2. When navigating to `ScreenB` and needing to use the same instance, the provider checks for the presence of the required instance in `SharedInstances`. If found, the instance is reused.
3. After `ScreenA` and `ScreenB` are removed from the widget tree, the corresponding instance is deleted from `SharedInstances`.

### Advantages

- Efficient memory usage by destroying instances when they are no longer needed.
- Avoidance of duplicating instances for different screens.
- Simplification of data management between screens through the reuse of instances.
