### PR TITLE
Fix typos

### DIFF
--- a/packages/provider/lib/src/provider.dart
+++ b/packages/provider/lib/src/provider.dart
@@ -665,9 +665,9 @@ extension WatchContext on BuildContext {
   /// ```dart
   /// runApp(
   ///   Builder(builder: (context) {
-  ///     final value = context.watch<Movie?>();
+  ///     final movie = context.watch<Movie?>();
   ///
-  ///     if (value == null) Text('no Movie found');
+  ///     if (movie == null) Text('no Movie found');
   ///     return Text(movie.title);
   ///   }),
   /// );


### PR DESCRIPTION
This version may also acceptable.
```dart
 runApp(
   Builder(builder: (context) {
     final value = context.watch<Movie?>();

     if (value == null) Text('no Movie found');
     return Text(value.title);
   }),
 );
```

</br>

But I think this version is more self-explanatory.
```dart
 runApp(
   Builder(builder: (context) {
     final movie = context.watch<Movie?>();

     if (movie == null) Text('no Movie found');
     return Text(movie.title);
   }),
 );
```

