### PR TITLE
Add tryRead Extension to BuildContext

### DIFF
--- a/packages/provider/lib/provider.dart
+++ b/packages/provider/lib/provider.dart
@@ -42,7 +42,8 @@ export 'src/provider.dart'
         SelectContext,
         StartListening,
         UpdateShouldNotify,
-        WatchContext;
+        WatchContext,
+        TryReadContext;
 export 'src/proxy_provider.dart'
     show
         ProxyProvider,

--- a/packages/provider/lib/src/provider.dart
+++ b/packages/provider/lib/src/provider.dart
@@ -684,6 +684,44 @@ extension ReadContext on BuildContext {
   }
 }
 
+/// Exposes the [tryRead] method.
+extension TryReadContext on BuildContext {
+  /// Attempt to obtain a value from the nearest ancestor provider of type [T].
+  ///
+  /// This method is similar to [read], but instead of throwing an exception if
+  /// the provider is not found or the value is null, it will safely return `null`.
+  ///
+  /// This is useful when you want to optionally obtain a provider's value without
+  /// risking an exception if the provider does not exist or returns null.
+  ///
+  /// Example usage:
+  ///
+  /// ```dart
+  /// final model = context.tryRead<Model>();
+  /// if (model != null) {
+  ///   // Use model
+  /// }
+  /// ```
+  ///
+  /// See also:
+  ///
+  /// - [ReadContext] and its [read] method, which throws if the provider is not found or returns null.
+  /// - [WatchContext] and its `watch` method, which makes widgets rebuild when the value changes.
+  T? tryRead<T>() {
+    final element = Provider._inheritedElementOf<T>(this);
+    if (element == null) return null;
+    final value = element.value;
+    // In sound mode, check type.
+    if (_isSoundMode) {
+      if (value is! T) {
+        return null;
+      }
+      return value;
+    }
+    return value;
+  }
+}
+
 /// Exposes the [watch] method.
 extension WatchContext on BuildContext {
   /// Obtain a value from the nearest ancestor provider of type [T] or [T?], and subscribe

--- a/packages/provider/test/null_safe/provider_test.dart
+++ b/packages/provider/test/null_safe/provider_test.dart
@@ -383,6 +383,79 @@ void main() {
       expect(curr, equals(25));
       expect(buildCount, equals(2));
     });
+
+    testWidgets('tryRead returns value if provider exists', (tester) async {
+      late int? value;
+      final builder = Builder(
+        builder: (context) {
+          value = context.tryRead<int>();
+          return Container();
+        },
+      );
+
+      await tester.pumpWidget(
+        Provider<int>.value(
+          value: 123,
+          child: builder,
+        ),
+      );
+
+      expect(value, equals(123));
+    });
+
+    testWidgets('tryRead returns null if provider does not exist',
+        (tester) async {
+      late int? value;
+      final builder = Builder(
+        builder: (context) {
+          value = context.tryRead<int>();
+          return Container();
+        },
+      );
+
+      await tester.pumpWidget(builder);
+
+      expect(value, isNull);
+    });
+
+    testWidgets('tryRead returns null if provider value is null',
+        (tester) async {
+      late int? value;
+      final builder = Builder(
+        builder: (context) {
+          value = context.tryRead<int>();
+          return Container();
+        },
+      );
+
+      await tester.pumpWidget(
+        Provider<int?>.value(
+          value: null,
+          child: builder,
+        ),
+      );
+
+      expect(value, isNull);
+    });
+
+    testWidgets('tryRead returns null if type does not match', (tester) async {
+      late String? value;
+      final builder = Builder(
+        builder: (context) {
+          value = context.tryRead<String>();
+          return Container();
+        },
+      );
+
+      await tester.pumpWidget(
+        Provider<int>.value(
+          value: 42,
+          child: builder,
+        ),
+      );
+
+      expect(value, isNull);
+    });
   });
 
   testWidgets('sound provide T inject T?', (tester) async {


### PR DESCRIPTION
**Overview**

This PR introduces a new extension, TryReadContext, for Flutter’s BuildContext, adding a tryRead<T>() method to complement the existing read<T>() method from the provider pattern.

**What’s New**
- tryRead<T>() method:
- Safely attempts to read a provider of type T from the nearest ancestor.
- Returns null if the provider is not found or is null, rather than throwing an exception.
- Useful for optional dependencies or when you need to gracefully handle missing providers.

**Why?**
- tryRead provides a safer way to access providers in scenarios where a provider might be missing.
- Prevents unexpected runtime exceptions that can occur when using read with non-existent providers.
- Makes the codebase more robust and easier to maintain, especially in large modular apps.

Example

```
final value = context.tryRead<MyService>();
if (value != null) {
  value.doSomething();
}
```

**Test Coverage**

- Added test cases for tryRead:
- Ensures it returns null if the provider does not exist.
- Ensures it returns the correct value if the provider is available.

**Notes**

- The extension is fully documented following the style of the existing read documentation.
- Usage is consistent with provider best practices.
- Does not cause widget rebuilds, similar to read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new method to safely access provider values without throwing exceptions if the provider is missing or the value is null.

* **Tests**
  * Added tests to verify the new safe access method returns the expected results in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->