### PR TITLE
fix: resolve Split import conflict by hiding Flutter's Split class

### DIFF
--- a/packages/provider/test/null_safe/multi_provider_test.dart
+++ b/packages/provider/test/null_safe/multi_provider_test.dart
@@ -11,7 +11,7 @@ void main() {
       await tester.pumpWidget(
         MultiProvider(
           providers: [
-            for (var i = 0; i < 500; i++) Provider<int>.value(value: i),
+            for (var i = 0; i < 1500; i++) Provider<int>.value(value: i),
           ],
           child: Container(),
         ),


### PR DESCRIPTION
- Hide Split from flutter/material.dart import to avoid naming conflict
- Keep using Split from devtools_app_shared/ui.dart
- No UI changes, only resolves compilation error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a naming/import conflict in the devtools extension to prevent potential runtime issues; no UI or public API changes expected.

- **Tests**
  - Reduced stress/scale in a provider test to make the test suite more efficient and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->