### PR TITLE
test: correct usage of ChangeNotifiers in context_test.dart

### DIFF
--- a/packages/provider/test/null_safe/context_test.dart
+++ b/packages/provider/test/null_safe/context_test.dart
@@ -488,12 +488,13 @@ void main() {
 
   testWidgets('watch in listView', (tester) async {
     final notifier = ValueNotifier([0, 0]);
+    addTearDown(notifier.dispose);
 
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: ChangeNotifierProvider(
-          create: (_) => notifier,
+        child: ChangeNotifierProvider.value(
+          value: notifier,
           child: ListView.builder(
             itemCount: 2,
             itemBuilder: (context, index) {
@@ -521,12 +522,13 @@ void main() {
 
   testWidgets('watch in gridView', (tester) async {
     final notifier = ValueNotifier([0, 0]);
+    addTearDown(notifier.dispose);
 
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: ChangeNotifierProvider(
-          create: (_) => notifier,
+        child: ChangeNotifierProvider.value(
+          value: notifier,
           child: GridView.builder(
             gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: 2,
@@ -558,6 +560,7 @@ void main() {
   group('BuildContext', () {
     testWidgets('internal selected value is updated', (tester) async {
       final notifier = ValueNotifier([false, false, false]);
+      addTearDown(notifier.dispose);
 
       final callCounts = <int, int>{
         0: 0,
@@ -577,8 +580,8 @@ void main() {
       }
 
       await tester.pumpWidget(
-        ChangeNotifierProvider(
-          create: (_) => notifier,
+        ChangeNotifierProvider.value(
+          value: notifier,
           child: Directionality(
             textDirection: TextDirection.ltr,
             child: Column(


### PR DESCRIPTION
These tests fail when Flutter automatically cleans up unused `InheritedWidget` dependencies as noted by @justinmc in https://github.com/flutter/flutter/pull/170104.

As per https://pub.dev/documentation/provider/latest/provider/ChangeNotifierProvider-class.html#:~:text=DON%27T%20reuse%20an%20existing%20ChangeNotifier%20using%20the%20default%20constructor already existing `ChangeNotifier` instances should not be passed into the `create` method of a `ChangeNotifierProvider` Widget (because it would then tie it to its own lifecycle). Instead instances can be passed through `ChangeNotifierProvider.value` and then disposing can be manually handled by the caller (in case of these tests via `addTearDown`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test provider initialization to improve resource management and disposal patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->