### PR TITLE
Docs: Clarify context.read and context.watch usage

### DIFF
--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -190,7 +190,7 @@ The easiest way to read a value is by using the extension methods on [BuildConte
 
 One can also use the static method `Provider.of<T>(context)`, which will behave exactly
 like `watch`. When the `listen` parameter is set to `false` (as in `Provider.of<T>(context, listen: false)`), then
-it will behave exactly as `read`.
+it will behave exactly like `read`.
 
 It's worth noting that `context.read<T>()` won't make a widget rebuild when the value
 changes and it shouldn't be called inside `StatelessWidget.build`/`State.build`.

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -193,8 +193,9 @@ to `watch`. When the `listen` parameter is set to `false` (as in `Provider.of<T>
 it will behave similarly to `read`.
 
 It's worth noting that `context.read<T>()` won't make a widget rebuild when the value
-changes and it cannot be called inside `StatelessWidget.build`/`State.build`.
+changes and it shouldn't be called inside `StatelessWidget.build`/`State.build`.
 On the other hand, it can be freely called outside of these methods.
+Instead, `context.watch<T>()` cannot be called outside `StatelessWidget.build`/`State.build`.
 
 These methods will look up in the widget tree starting from the widget associated
 with the `BuildContext` passed and will return the nearest variable of type `T`

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -195,7 +195,7 @@ it will behave exactly like `read`.
 It's worth noting that `context.read<T>()` won't make a widget rebuild when the value
 changes and it shouldn't be called inside `StatelessWidget.build`/`State.build`.
 On the other hand, it can be freely called outside of these methods.
-Instead, `context.watch<T>()` cannot be called outside `StatelessWidget.build`/`State.build`.
+Instead, `context.watch<T>()` can only be called inside `StatelessWidget.build`/`State.build` or Providers's `update` method.
 
 These methods will look up in the widget tree starting from the widget associated
 with the `BuildContext` passed and will return the nearest variable of type `T`

--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -188,9 +188,9 @@ The easiest way to read a value is by using the extension methods on [BuildConte
 - `context.read<T>()`, which returns `T` without listening to it
 - `context.select<T, R>(R cb(T value))`, which allows a widget to listen to only a small part of `T`.
 
-One can also use the static method `Provider.of<T>(context)`, which will behave similarly
-to `watch`. When the `listen` parameter is set to `false` (as in `Provider.of<T>(context, listen: false)`), then
-it will behave similarly to `read`.
+One can also use the static method `Provider.of<T>(context)`, which will behave exactly
+like `watch`. When the `listen` parameter is set to `false` (as in `Provider.of<T>(context, listen: false)`), then
+it will behave exactly as `read`.
 
 It's worth noting that `context.read<T>()` won't make a widget rebuild when the value
 changes and it shouldn't be called inside `StatelessWidget.build`/`State.build`.

--- a/packages/provider/lib/src/provider.dart
+++ b/packages/provider/lib/src/provider.dart
@@ -715,7 +715,7 @@ extension WatchContext on BuildContext {
   ///
   /// This method is accessible only inside [StatelessWidget.build] and
   /// [State.build].\
-  /// If you need to use it outside of these methods, consider using [Provider.of]
+  /// If you need to use it outside of these methods, consider using [ReadContext.read]
   /// instead, which doesn't have this restriction.\
   /// The only exception to this rule is Providers's `update` method.
   ///

--- a/resources/translations/it_IT/README.md
+++ b/resources/translations/it_IT/README.md
@@ -181,10 +181,11 @@ Il modo più semplice per leggere un valore è utilizzare i metodi di estensione
 - `context.read<T>()`, che restituisce `T` senza ascoltarlo
 - `context.select<T, R>(R cb(T value))`, che consente a un widget di ascoltare solo una piccola parte di `T`.
 
-Si può anche usare il metodo statico `Provider.of<T>(context)`, che si comporterà in modo simile a `watch`. Quando il parametro `listen` è impostato su `false` (come in `Provider.of<T>(context, listen: false)`), si comporterà in modo simile a `read`.
+Si può anche usare il metodo statico `Provider.of<T>(context)`, che si comporterà esattamente come `watch`. Quando il parametro `listen` è impostato su `false` (come in `Provider.of<T>(context, listen: false)`), si comporterà esattamente come `read`.
 
-Vale la pena notare che `context.read<T>()` non farà ricostruire un widget quando il valore cambia e non può essere chiamato all'interno di `StatelessWidget.build`/`State.build`.
+Vale la pena notare che `context.read<T>()` non farà ricostruire un widget quando il valore cambia e non dovrebbe essere chiamato all'interno di `StatelessWidget.build`/`State.build`.
 D'altra parte, può essere chiamato liberamente al di fuori di questi metodi.
+Invece, `context.watch<T>()` non può essere chiamato fuori da `StatelessWidget.build`/`State.build`.
 
 Questi metodi cercheranno nell'albero dei widget a partire dal widget associato al `BuildContext` passato e restituiranno la variabile più vicina di tipo `T` trovata (o lanceranno un'eccezione se nulla viene trovato).
 

--- a/resources/translations/it_IT/README.md
+++ b/resources/translations/it_IT/README.md
@@ -185,7 +185,7 @@ Si può anche usare il metodo statico `Provider.of<T>(context)`, che si comporte
 
 Vale la pena notare che `context.read<T>()` non farà ricostruire un widget quando il valore cambia e non dovrebbe essere chiamato all'interno di `StatelessWidget.build`/`State.build`.
 D'altra parte, può essere chiamato liberamente al di fuori di questi metodi.
-Invece, `context.watch<T>()` non può essere chiamato fuori da `StatelessWidget.build`/`State.build`.
+Invece, `context.watch<T>()` può essere chiamato solo dentro `StatelessWidget.build`/`State.build` o il metodo `update` dei Provider.
 
 Questi metodi cercheranno nell'albero dei widget a partire dal widget associato al `BuildContext` passato e restituiranno la variabile più vicina di tipo `T` trovata (o lanceranno un'eccezione se nulla viene trovato).
 


### PR DESCRIPTION
 [Here (pub website)](https://pub.dev/packages/provider) you can clearly read:

> It's worth noting that `context.read<T>()` won't make a widget rebuild when the value changes and it **cannot** be called inside `StatelessWidget.build/State.build`. On the other hand, it can be freely called outside of these methods.

However, as also stated here #848, this is false. In fact, you can indeed call `context.read<T>()` inside a `StatelessWidget.build/State.build`. Therefore, "cannot" should be changed into "shouldn't".

This was already pointed out in #848. However, the commit ad975c0 that marked the issue as solved only addressed the comments in the source code, but not in the README of [the pub website](https://pub.dev/packages/provider).

Moreover, I would add the following description to the documentation:

> `context.watch<T>()` **cannot** be called outside `StatelessWidget.build/State.build` or Providers' `update` method.

In fact, if you try to call `context.watch<T>()` outside the build method, you'll get:

> Tried to listen to a value exposed with provider, from outside of the widget tree. This is likely caused by an event handler (like a button's `onPressed`) that called `Provider.of` without passing `listen: false`.

Then, this is what you can read in the source code about `context.watch`:

>  /// This method is accessible only inside [StatelessWidget.build] and
  /// [State.build].\
  /// If you need to use it outside of these methods, **consider using [Provider.of]**
  /// instead, which doesn't have this restriction.\

`Provider.of` defaults `listen: true`, therefore acting like `context.watch<T>()`, therefore the above comment in bold doesn't make much sense.

Finally, I wanted to point out that `Provider.of<T>(context)` and `context.read<T>()` don't just behave similarly, but they are completely identical. Specular case for `context.watch<T>()`.
Some people on Stackoverflow were a bit confused about the phrasing on the documentation, as you can see [here](https://stackoverflow.com/q/62257064/7339411).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Provider.of behaves exactly like context.watch and that its listen:false form behaves like context.read.
  * Revised guidance: context.read “should not” be called inside StatelessWidget.build/State.build; context.watch is limited to those build/update contexts.
  * Clarified lookup: returns nearest instance, may throw if absent, and is O(1) (does not walk the widget tree).
  * Updated Italian README to match these clarifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->