### PR TITLE
Fix assertion failure when a provider depends on an ancestor of the same type (#796)

### DIFF
--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- Fixed an assertion failure when a provider depends on an ancestor provider of
+  the same type it provides (such as a `ProxyProvider<T, T>` or using
+  `context.watch<T>()`/`Provider.of<T>()` inside a `ProxyProvider0<T>`'s
+  `update`). The provider used to register a dependency on itself, which threw
+  inside `InheritedElement.notifyClients` on rebuild (#796).
+
 ## 6.1.5+1 - 2025-08-19
 
 Updated Discord link.

--- a/packages/provider/lib/src/provider.dart
+++ b/packages/provider/lib/src/provider.dart
@@ -327,11 +327,21 @@ The context used was: $context
     final inheritedElement = _inheritedElementOf<T>(context);
 
     if (listen) {
-      // bind context with the element
-      // We have to use this method instead of dependOnInheritedElement, because
-      // dependOnInheritedElement does not support relocating using GlobalKey
-      // if no provider were found previously.
-      context.dependOnInheritedWidgetOfExactType<_InheritedProviderScope<T?>>();
+      if (inheritedElement != null) {
+        // bind context with the element.
+        // We use dependOnInheritedElement instead of
+        // dependOnInheritedWidgetOfExactType because the latter would resolve
+        // to the nearest provider of that type, which is the context itself
+        // when a provider depends on an ancestor provider of the same type
+        // (such as a ProxyProvider<T, T>). Depending on oneself triggers an
+        // assertion failure when the dependents are later notified.
+        context.dependOnInheritedElement(inheritedElement);
+      } else {
+        // tell Flutter to rebuild the widget when relocated using GlobalKey
+        // if no provider were found previously.
+        context
+            .dependOnInheritedWidgetOfExactType<_InheritedProviderScope<T?>>();
+      }
     }
 
     final value = inheritedElement?.value;

--- a/packages/provider/test/null_safe/proxy_provider_test.dart
+++ b/packages/provider/test/null_safe/proxy_provider_test.dart
@@ -150,6 +150,63 @@ void main() {
       verifyNoMoreInteractions(combiner);
     });
 
+    testWidgets(
+        'can depend on an ancestor provider of the same type it provides '
+        '(regression #796)', (tester) async {
+      // Provides a [String] while also depending on an ancestor [String] of
+      // the same type. Rebuilding the proxy used to trigger an assertion
+      // failure inside InheritedElement.notifyClients because the proxy ended
+      // up depending on itself instead of the ancestor.
+      Widget build(String suffix) {
+        return Provider<String>.value(
+          value: 'base',
+          child: ProxyProvider0<String>(
+            update: (context, _) {
+              final base = Provider.of<String>(context);
+              return '$base-$suffix';
+            },
+            child: TextOf<String>(),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(build('a'));
+
+      expect(find.text('base-a'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      // Rebuilding with a new parameter forces the proxy to rebuild, which is
+      // where the assertion used to be thrown.
+      await tester.pumpWidget(build('b'));
+
+      expect(find.text('base-b'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+        'ProxyProvider can consume an ancestor of the same type it provides '
+        '(regression #796)', (tester) async {
+      Widget build(String suffix) {
+        return Provider<String>.value(
+          value: 'base',
+          child: ProxyProvider<String, String>(
+            update: (context, base, _) => '$base-$suffix',
+            child: TextOf<String>(),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(build('a'));
+
+      expect(find.text('base-a'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      await tester.pumpWidget(build('b'));
+
+      expect(find.text('base-b'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('rebuild descendants if value change', (tester) async {
       await tester.pumpWidget(
         MultiProvider(


### PR DESCRIPTION
## Description

Fixes #796.

When a provider both **provides** a value of type `T` and **depends on** an ancestor value of the same type `T`, rebuilding it threw an assertion failure inside Flutter's `InheritedElement.notifyClients`:

```
'package:flutter/src/widgets/framework.dart': Failed assertion: ... // check that it really is our descendant
```

This happens with, for example:

```dart
Provider<AppTheme>(
  create: (_) => AppTheme(),
  child: ProxyProvider0<AppTheme>(
    update: (context, _) => PartialAppTheme(Provider.of<AppTheme>(context)),
    child: ...,
  ),
);
```

or the equivalent `ProxyProvider<AppTheme, AppTheme>`.

## Root cause

`Provider.of<T>` resolves the ancestor `_InheritedProviderScope<T?>` element through the custom `getElementForInheritedWidgetOfExactType` override, which correctly **skips the element itself** when walking up the tree. However, it then registered the dependency with Flutter's standard `context.dependOnInheritedWidgetOfExactType<_InheritedProviderScope<T?>>()`, which resolves to the **nearest** provider of that type.

When the call originates from inside a provider that exposes the same type it consumes, that nearest provider *is the element itself*, so the element registered a dependency on **itself**. On the next rebuild, `notifyClients` iterates its dependents and asserts each one is a descendant — the element is not a descendant of itself, so the assertion fails.

## Fix

`Provider.of` now depends on the resolved ancestor element directly via `dependOnInheritedElement`, mirroring the logic already used by `context.select`. It only falls back to `dependOnInheritedWidgetOfExactType` when no provider was found (preserving GlobalKey relocation support).

## Tests

Added two regression tests in `proxy_provider_test.dart` covering both `ProxyProvider0<T>` + `Provider.of<T>` and `ProxyProvider<T, T>`. Both fail on `master` with the original assertion and pass with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an assertion issue that could occur when a provider depends on an ancestor provider of the same type.
  * Improved rebuild handling so values update correctly when providers move or are rebuilt.
  * Added regression coverage to ensure related provider setups render updated content without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->